### PR TITLE
Add 3-level elevation system and strengthen syntax highlighting

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,6 +23,14 @@ html[data-theme="dark"] {
     --header-height: 48px;
     --sidebar-width: 240px;
     --resize-handle-width: 5px;
+    /* Syntax token colors */
+    --tok-keyword: #ffffff;
+    --tok-type:    #d0d0d0;
+    --tok-string:  #a8a8a8;
+    --tok-number:  #909090;
+    --tok-comment: #505050;
+    --tok-builtin: #c0c0c0;
+    --tok-operator: #e8e8e8;
 }
 
 /* Light theme */
@@ -44,6 +52,14 @@ html[data-theme="light"] {
     --header-height: 48px;
     --sidebar-width: 240px;
     --resize-handle-width: 5px;
+    /* Syntax token colors */
+    --tok-keyword: #000000;
+    --tok-type:    #222222;
+    --tok-string:  #555555;
+    --tok-number:  #666666;
+    --tok-comment: #999999;
+    --tok-builtin: #333333;
+    --tok-operator: #111111;
 }
 
 /* System preference fallback (when no data-theme set yet) */
@@ -61,6 +77,13 @@ html[data-theme="light"] {
         --color-accent-green: #444444;
         --color-accent-orange: #555555;
         --color-accent-red: #222222;
+        --tok-keyword: #000000;
+        --tok-type:    #222222;
+        --tok-string:  #555555;
+        --tok-number:  #666666;
+        --tok-comment: #999999;
+        --tok-builtin: #333333;
+        --tok-operator: #111111;
     }
 }
 
@@ -771,3 +794,40 @@ main {
     letter-spacing: 0.05em;
 }
 .tree-datasheet-link:hover { text-decoration: underline; }
+
+/* =====================================================================
+   Syntax Highlighting Token Classes
+   ===================================================================== */
+.tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
+.tok-type     { color: var(--tok-type); }
+.tok-string   { color: var(--tok-string); }
+.tok-number   { color: var(--tok-number); }
+.tok-comment  { color: var(--tok-comment); font-style: italic; }
+.tok-builtin  { color: var(--tok-builtin); }
+.tok-operator { color: var(--tok-operator); }
+
+/* =====================================================================
+   Autosave Toggle
+   ===================================================================== */
+.autosave-toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    user-select: none;
+}
+.autosave-toggle input {
+    accent-color: var(--color-text-primary);
+    cursor: pointer;
+}
+#autosave-label {
+    transition: opacity 0.5s ease, transform 0.5s ease;
+    white-space: nowrap;
+}
+#autosave-label.fade-out {
+    opacity: 0;
+    transform: translateX(-8px);
+}
+#autosave-label.hidden { display: none; }

--- a/css/style.css
+++ b/css/style.css
@@ -23,14 +23,14 @@ html[data-theme="dark"] {
     --header-height: 48px;
     --sidebar-width: 240px;
     --resize-handle-width: 5px;
-    /* Syntax token colors */
-    --tok-keyword: #ffffff;
-    --tok-type:    #d0d0d0;
-    --tok-string:  #a8a8a8;
-    --tok-number:  #909090;
-    --tok-comment: #505050;
-    --tok-builtin: #c0c0c0;
-    --tok-operator: #e8e8e8;
+    /* Syntax token colors — matches hotnote brand theme (dark) */
+    --tok-keyword: #e8bcd4;    /* muted pink — keywords, types, class names */
+    --tok-type:    #e8bcd4;    /* muted pink */
+    --tok-string:  #b8e5f2;    /* muted cyan — strings, variables, properties */
+    --tok-number:  #c8bce8;    /* muted purple — numbers, booleans, operators */
+    --tok-comment: #888888;    /* gray — comments */
+    --tok-builtin: #b8e5f2;    /* muted cyan — builtins */
+    --tok-operator: #c8bce8;   /* muted purple */
 }
 
 /* Light theme */
@@ -52,14 +52,14 @@ html[data-theme="light"] {
     --header-height: 48px;
     --sidebar-width: 240px;
     --resize-handle-width: 5px;
-    /* Syntax token colors */
-    --tok-keyword: #000000;
-    --tok-type:    #222222;
-    --tok-string:  #555555;
-    --tok-number:  #666666;
-    --tok-comment: #999999;
-    --tok-builtin: #333333;
-    --tok-operator: #111111;
+    /* Syntax token colors — matches hotnote brand theme (light) */
+    --tok-keyword: #a65580;    /* darker muted pink — keywords, types, class names */
+    --tok-type:    #a65580;    /* darker muted pink */
+    --tok-string:  #5a9cb8;    /* darker muted cyan — strings, variables, properties */
+    --tok-number:  #7a65ad;    /* darker muted purple — numbers, booleans, operators */
+    --tok-comment: #999999;    /* gray — comments */
+    --tok-builtin: #5a9cb8;    /* darker muted cyan — builtins */
+    --tok-operator: #7a65ad;   /* darker muted purple */
 }
 
 /* System preference fallback (when no data-theme set yet) */
@@ -77,13 +77,13 @@ html[data-theme="light"] {
         --color-accent-green: #444444;
         --color-accent-orange: #555555;
         --color-accent-red: #222222;
-        --tok-keyword: #000000;
-        --tok-type:    #222222;
-        --tok-string:  #555555;
-        --tok-number:  #666666;
+        --tok-keyword: #a65580;
+        --tok-type:    #a65580;
+        --tok-string:  #5a9cb8;
+        --tok-number:  #7a65ad;
         --tok-comment: #999999;
-        --tok-builtin: #333333;
-        --tok-operator: #111111;
+        --tok-builtin: #5a9cb8;
+        --tok-operator: #7a65ad;
     }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -808,6 +808,44 @@ main {
 .s3-wysiwyg pre code .tok-operator { color: var(--tok-operator); }
 
 /* =====================================================================
+   Code Highlight View (standalone code file viewer)
+   ===================================================================== */
+.code-highlight-view {
+    flex: 1;
+    overflow: auto;
+    background: var(--color-bg-primary);
+    padding: 0;
+}
+
+.code-highlight-pre {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    white-space: pre;
+    min-height: 100%;
+    box-sizing: border-box;
+    color: var(--color-text-primary);
+}
+
+.code-highlight-pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+}
+
+.code-highlight-pre .tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
+.code-highlight-pre .tok-type     { color: var(--tok-type); }
+.code-highlight-pre .tok-string   { color: var(--tok-string); }
+.code-highlight-pre .tok-number   { color: var(--tok-number); }
+.code-highlight-pre .tok-comment  { color: var(--tok-comment); font-style: italic; }
+.code-highlight-pre .tok-builtin  { color: var(--tok-builtin); }
+.code-highlight-pre .tok-operator { color: var(--tok-operator); }
+
+/* =====================================================================
    Autosave Toggle
    ===================================================================== */
 .autosave-toggle {

--- a/css/style.css
+++ b/css/style.css
@@ -797,14 +797,15 @@ main {
 
 /* =====================================================================
    Syntax Highlighting Token Classes
+   Use .s3-wysiwyg pre code prefix to beat the color rule on <code>
    ===================================================================== */
-.tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
-.tok-type     { color: var(--tok-type); }
-.tok-string   { color: var(--tok-string); }
-.tok-number   { color: var(--tok-number); }
-.tok-comment  { color: var(--tok-comment); font-style: italic; }
-.tok-builtin  { color: var(--tok-builtin); }
-.tok-operator { color: var(--tok-operator); }
+.s3-wysiwyg pre code .tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
+.s3-wysiwyg pre code .tok-type     { color: var(--tok-type); }
+.s3-wysiwyg pre code .tok-string   { color: var(--tok-string); }
+.s3-wysiwyg pre code .tok-number   { color: var(--tok-number); }
+.s3-wysiwyg pre code .tok-comment  { color: var(--tok-comment); font-style: italic; }
+.s3-wysiwyg pre code .tok-builtin  { color: var(--tok-builtin); }
+.s3-wysiwyg pre code .tok-operator { color: var(--tok-operator); }
 
 /* =====================================================================
    Autosave Toggle

--- a/css/style.css
+++ b/css/style.css
@@ -13,24 +13,29 @@ html[data-theme="dark"] {
     --color-border-secondary: #202020;
     --color-text-primary: #e8e8e8;
     --color-text-secondary: #909090;
-    --color-text-tertiary: #484848;
+    --color-text-tertiary: #626262;
     --color-accent-blue: #c8c8c8;
     --color-accent-green: #a0a0a0;
     --color-accent-orange: #b0b0b0;
     --color-accent-red: #787878;
     --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
-    --panel-border-radius: 2px;
-    --header-height: 48px;
-    --sidebar-width: 240px;
-    --resize-handle-width: 5px;
-    /* Syntax token colors — matches hotnote brand theme (dark) */
-    --tok-keyword: #e8bcd4;    /* muted pink — keywords, types, class names */
-    --tok-type:    #e8bcd4;    /* muted pink */
-    --tok-string:  #b8e5f2;    /* muted cyan — strings, variables, properties */
-    --tok-number:  #c8bce8;    /* muted purple — numbers, booleans, operators */
-    --tok-comment: #888888;    /* gray — comments */
-    --tok-builtin: #b8e5f2;    /* muted cyan — builtins */
-    --tok-operator: #c8bce8;   /* muted purple */
+    --panel-border-radius: 0;
+    --header-height: 58px;
+    --sidebar-width: 288px;
+    --resize-handle-width: 6px;
+    /* Syntax token colors — vivid but not garish */
+    --tok-keyword: #d070b8;    /* magenta-rose */
+    --tok-type:    #d070b8;
+    --tok-string:  #58cce0;    /* bright cyan */
+    --tok-number:  #b098e8;    /* bright lavender */
+    --tok-comment: #666666;    /* mid gray */
+    --tok-builtin: #58cce0;
+    --tok-operator: #b098e8;
+    --shadow-sm:        0 1px 3px rgba(0,0,0,0.30), 0 1px 1px rgba(0,0,0,0.18);
+    --shadow-md:        0 2px 8px rgba(0,0,0,0.35), 0 1px 3px rgba(0,0,0,0.20);
+    --shadow-lg:        0 12px 40px rgba(0,0,0,0.55), 0 4px 14px rgba(0,0,0,0.30);
+    --highlight-top:    inset 0 1px 0 rgba(255,255,255,0.055);
+    --focus-glow:       rgba(232,232,232,0.10);
 }
 
 /* Light theme */
@@ -48,18 +53,23 @@ html[data-theme="light"] {
     --color-accent-orange: #555555;
     --color-accent-red: #222222;
     --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
-    --panel-border-radius: 2px;
-    --header-height: 48px;
-    --sidebar-width: 240px;
-    --resize-handle-width: 5px;
-    /* Syntax token colors — matches hotnote brand theme (light) */
-    --tok-keyword: #a65580;    /* darker muted pink — keywords, types, class names */
-    --tok-type:    #a65580;    /* darker muted pink */
-    --tok-string:  #5a9cb8;    /* darker muted cyan — strings, variables, properties */
-    --tok-number:  #7a65ad;    /* darker muted purple — numbers, booleans, operators */
-    --tok-comment: #999999;    /* gray — comments */
-    --tok-builtin: #5a9cb8;    /* darker muted cyan — builtins */
-    --tok-operator: #7a65ad;   /* darker muted purple */
+    --panel-border-radius: 0;
+    --header-height: 58px;
+    --sidebar-width: 288px;
+    --resize-handle-width: 6px;
+    /* Syntax token colors — clear and readable on light backgrounds */
+    --tok-keyword: #8b0a5a;    /* deep crimson-magenta */
+    --tok-type:    #8b0a5a;
+    --tok-string:  #0a5a78;    /* deep teal */
+    --tok-number:  #3a1888;    /* deep violet */
+    --tok-comment: #909090;    /* mid gray */
+    --tok-builtin: #0a5a78;
+    --tok-operator: #3a1888;
+    --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
+    --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
+    --shadow-lg:        0 12px 40px rgba(0,0,0,0.20), 0 4px 14px rgba(0,0,0,0.10);
+    --highlight-top:    inset 0 1px 0 rgba(255,255,255,0.70);
+    --focus-glow:       rgba(17,17,17,0.08);
 }
 
 /* System preference fallback (when no data-theme set yet) */
@@ -77,13 +87,18 @@ html[data-theme="light"] {
         --color-accent-green: #444444;
         --color-accent-orange: #555555;
         --color-accent-red: #222222;
-        --tok-keyword: #a65580;
-        --tok-type:    #a65580;
-        --tok-string:  #5a9cb8;
-        --tok-number:  #7a65ad;
-        --tok-comment: #999999;
-        --tok-builtin: #5a9cb8;
-        --tok-operator: #7a65ad;
+        --tok-keyword: #8b0a5a;
+        --tok-type:    #8b0a5a;
+        --tok-string:  #0a5a78;
+        --tok-number:  #3a1888;
+        --tok-comment: #909090;
+        --tok-builtin: #0a5a78;
+        --tok-operator: #3a1888;
+        --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
+        --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
+        --shadow-lg:        0 12px 40px rgba(0,0,0,0.20), 0 4px 14px rgba(0,0,0,0.10);
+        --highlight-top:    inset 0 1px 0 rgba(255,255,255,0.70);
+        --focus-glow:       rgba(17,17,17,0.08);
     }
 }
 
@@ -96,6 +111,18 @@ html[data-theme="light"] {
     padding: 0;
 }
 
+html {
+    font-size: 120%; /* global 20% scale — all rem values grow with this */
+}
+
+/* Global focus ring — always visible for keyboard navigation */
+:focus-visible {
+    outline: 2px solid var(--color-text-primary);
+    outline-offset: 2px;
+}
+/* Wysiwyg handles its own focus */
+#wysiwyg:focus-visible { outline: none; }
+
 html, body {
     height: 100%;
     overflow: hidden;
@@ -103,7 +130,7 @@ html, body {
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-    font-size: 14px;
+    font-size: 0.875rem; /* 14px at default scale, 16.8px at 120% */
     line-height: 1.5;
     color: var(--color-text-primary);
     background: var(--color-bg-primary);
@@ -128,6 +155,7 @@ header {
     padding: 0 1rem;
     background: var(--color-bg-secondary);
     border-bottom: 1px solid var(--color-border-primary);
+    box-shadow: var(--shadow-md);
     flex-shrink: 0;
     z-index: 100;
 }
@@ -160,11 +188,14 @@ header {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 160px;
+    max-width: 192px;
 }
 
-#breadcrumb .crumb:hover {
+#breadcrumb .crumb:hover,
+#breadcrumb .crumb:focus-visible {
     text-decoration: underline;
+    outline: none;
+    opacity: 0.8;
 }
 
 #breadcrumb .crumb-sep {
@@ -188,14 +219,28 @@ main {
    ===================================================================== */
 #sidebar {
     width: var(--sidebar-width);
-    min-width: 120px;
-    max-width: 600px;
+    min-width: 144px;
+    max-width: 720px;
     display: flex;
     flex-direction: column;
     background: var(--color-bg-secondary);
     border-right: 1px solid var(--color-border-primary);
+    box-shadow: var(--shadow-md);
     overflow: hidden;
     flex-shrink: 0;
+    position: relative;
+    z-index: 1;
+    transition: width 0.18s ease;
+}
+
+#sidebar.collapsed {
+    width: 0 !important;
+    min-width: 0;
+    border-right: none;
+}
+
+#sidebar.collapsed + #resize-handle {
+    display: none;
 }
 
 #sidebar-toolbar {
@@ -224,7 +269,7 @@ main {
     color: var(--color-text-secondary);
     position: relative;
     user-select: none;
-    border-radius: 2px;
+    border-radius: var(--panel-border-radius);
     margin: 0 0.25rem;
 }
 
@@ -236,6 +281,7 @@ main {
 .file-entry.active {
     background: var(--color-bg-tertiary);
     color: var(--color-text-primary);
+    box-shadow: inset 2px 0 0 var(--color-text-primary);
 }
 
 .file-entry .icon {
@@ -263,20 +309,23 @@ main {
     border: none;
     color: var(--color-text-tertiary);
     cursor: pointer;
-    font-size: 0.7rem;
-    padding: 0 0.25rem;
-    line-height: 1;
+    padding: 0;
+    width: 1.5rem;
+    height: 1.5rem;
+    line-height: 0;
     flex-shrink: 0;
-    border-radius: 2px;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--panel-border-radius);
 }
 
 .file-entry:hover .delete-btn {
-    display: block;
+    display: flex;
 }
 
 .file-entry .delete-btn:hover {
-    color: var(--color-accent-red);
-    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    background: var(--color-bg-tertiary);
 }
 
 .new-file-input-wrap {
@@ -286,14 +335,21 @@ main {
 
 .new-file-input-wrap input {
     width: 100%;
-    padding: 0.25rem 0.4rem;
+    padding: 0.3rem 0.5rem;
     background: var(--color-bg-primary);
-    border: 1px solid var(--color-accent-blue);
+    border: 1px solid var(--color-text-secondary);
     color: var(--color-text-primary);
     font-size: 0.8125rem;
     font-family: var(--font-mono);
     outline: none;
     border-radius: var(--panel-border-radius);
+}
+
+.new-file-input-wrap input:focus {
+    border-color: var(--color-text-primary);
+    outline: 2px solid var(--color-text-primary);
+    outline-offset: 1px;
+    box-shadow: 0 0 0 3px var(--focus-glow);
 }
 
 /* =====================================================================
@@ -331,8 +387,11 @@ main {
     padding: 0.375rem 0.75rem;
     background: var(--color-bg-secondary);
     border-bottom: 1px solid var(--color-border-primary);
+    box-shadow: 0 1px 0 var(--color-border-primary), 0 2px 6px rgba(0,0,0,0.20);
     flex-shrink: 0;
-    min-height: 36px;
+    min-height: 44px;
+    position: relative;
+    z-index: 1;
 }
 
 #mode-toolbar .filename-display {
@@ -365,23 +424,92 @@ main {
     letter-spacing: 0.02em;
 }
 
-/* Source editor (textarea) */
-#source-editor {
+/* Source editor wrapper — takes flex-1 slot, hidden until source mode */
+#source-editor-wrap {
     flex: 1;
-    resize: none;
-    border: none;
-    outline: none;
+    position: relative;
+    overflow: hidden;
+    display: none;
     background: var(--color-bg-primary);
-    color: var(--color-text-primary);
+}
+
+/* Line number gutter */
+#line-numbers {
+    position: absolute;
+    top: 0; left: 0; bottom: 0;
+    width: 3.25rem;
+    padding: 0.75rem 0.5rem 0.75rem 0;
+    overflow: hidden;
+    pointer-events: none;
+    text-align: right;
     font-family: var(--font-mono);
     font-size: 0.8125rem;
     line-height: 1.5;
-    padding: 0.75rem;
+    color: var(--color-text-tertiary);
+    background: var(--color-bg-secondary);
+    border-right: 1px solid var(--color-border-secondary);
+    box-shadow: inset -3px 0 6px rgba(0,0,0,0.18);
+    white-space: pre;
+    user-select: none;
+    z-index: 2;
+}
+
+/* Syntax highlight backdrop — sits behind the transparent textarea */
+#source-highlight-backdrop {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    margin: 0;
+    padding: 0.75rem 0.75rem 0.75rem calc(3.25rem + 0.75rem);
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    tab-size: 4;
+    white-space: pre;
+    overflow: hidden;
+    pointer-events: none;
+    color: var(--color-text-primary);
+    word-break: normal;
+}
+
+#source-highlight-backdrop code {
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    white-space: pre;
+    tab-size: 4;
+}
+
+/* Source editor textarea — transparent overlay on top of backdrop */
+#source-editor {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    width: 100%;
+    height: 100%;
+    resize: none;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: transparent;
+    caret-color: var(--color-text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    padding: 0.75rem 0.75rem 0.75rem calc(3.25rem + 0.75rem);
     overflow: auto;
     tab-size: 4;
     white-space: pre;
-    display: none;
+    z-index: 1;
+    display: block;
 }
+
+/* Token colors for source editor backdrop */
+#source-highlight-backdrop .tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
+#source-highlight-backdrop .tok-type     { color: var(--tok-type); }
+#source-highlight-backdrop .tok-string   { color: var(--tok-string); }
+#source-highlight-backdrop .tok-number   { color: var(--tok-number); }
+#source-highlight-backdrop .tok-comment  { color: var(--tok-comment); font-style: italic; }
+#source-highlight-backdrop .tok-builtin  { color: var(--tok-builtin); }
+#source-highlight-backdrop .tok-operator { color: var(--tok-operator); }
 
 /* WYSIWYG preview */
 #wysiwyg {
@@ -418,60 +546,77 @@ main {
 .btn {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.3rem;
-    padding: 0.3rem 0.6rem;
-    font-size: 0.75rem;
+    padding: 0 0.75rem;
+    height: 2rem;
+    font-size: 0.8rem;
+    font-weight: 500;
     font-family: inherit;
+    letter-spacing: 0.02em;
     border: 1px solid var(--color-border-primary);
     background: var(--color-bg-tertiary);
     color: var(--color-text-primary);
     cursor: pointer;
     border-radius: var(--panel-border-radius);
     white-space: nowrap;
-    transition: background 0.15s, border-color 0.15s;
+    transition: background 0.12s, border-color 0.12s, color 0.12s, box-shadow 0.12s;
+    user-select: none;
+    box-shadow: var(--shadow-sm), var(--highlight-top);
 }
 
 .btn:hover:not(:disabled) {
-    background: var(--color-bg-secondary);
+    background: var(--color-bg-primary);
     border-color: var(--color-text-secondary);
+    box-shadow: var(--shadow-sm);
+}
+
+.btn:active:not(:disabled) {
+    background: var(--color-bg-secondary);
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.25);
 }
 
 .btn:disabled {
-    opacity: 0.45;
+    opacity: 0.4;
     cursor: not-allowed;
 }
 
 .btn.active {
-    background: var(--color-accent-blue);
-    border-color: var(--color-accent-blue);
-    color: var(--color-bg-primary);
-}
-
-.btn-primary {
-    background: var(--color-accent-blue);
-    border-color: var(--color-accent-blue);
-    color: var(--color-bg-primary);
-}
-
-.btn-primary:hover:not(:disabled) {
     background: var(--color-text-primary);
     border-color: var(--color-text-primary);
     color: var(--color-bg-primary);
+    box-shadow: none;
 }
 
+.btn-primary {
+    background: var(--color-text-primary);
+    border-color: var(--color-text-primary);
+    color: var(--color-bg-primary);
+    box-shadow: none;
+}
+
+.btn-primary:hover:not(:disabled) {
+    background: var(--color-text-secondary);
+    border-color: var(--color-text-secondary);
+    color: var(--color-bg-primary);
+}
+
+/* Smaller variant — same height, tighter horizontal padding */
 .btn-sm {
-    padding: 0.2rem 0.5rem;
-    font-size: 0.7rem;
+    padding: 0 0.55rem;
+    font-size: 0.75rem;
 }
 
+/* Icon-only button — fixed square */
 .btn-icon {
-    padding: 0.25rem;
+    width: 2rem;
+    padding: 0;
     line-height: 0;
 }
 
 #save-btn.dirty {
-    background: var(--color-accent-blue);
-    border-color: var(--color-accent-blue);
+    background: var(--color-text-primary);
+    border-color: var(--color-text-primary);
     color: var(--color-bg-primary);
 }
 
@@ -496,7 +641,8 @@ main {
     background: var(--color-bg-secondary);
     border: 1px solid var(--color-border-primary);
     border-radius: var(--panel-border-radius);
-    max-width: 800px;
+    box-shadow: var(--shadow-lg);
+    max-width: 960px;
     width: 90vw;
     max-height: 80vh;
     display: flex;
@@ -531,21 +677,25 @@ main {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
     font-size: 0.9375rem;
     line-height: 1.75;
-    letter-spacing: 0.025em;
-    word-spacing: 0.08em;
+    letter-spacing: 0.02em;
+    word-spacing: 0.05em;
     white-space: normal;
     overflow-wrap: break-word;
-    padding: 0.75rem 1rem;
     background: var(--color-bg-primary);
     overflow: auto;
+}
+
+/* Constrain reading width and center — padding grows to center at ~72ch */
+#wysiwyg.s3-wysiwyg {
+    padding: 2rem max(2rem, calc((100% - 72ch) / 2));
 }
 
 .s3-wysiwyg:focus { outline: none; }
 
 .s3-wysiwyg h1 {
-    font-size: 2em; font-weight: 700; letter-spacing: 0.08em; word-spacing: 0.12em;
-    border-bottom: 2px solid var(--color-border-primary); padding-bottom: 0.3em;
-    margin: 1em 0 0.5em; color: var(--color-accent-blue); text-transform: uppercase;
+    font-size: 1.875em; font-weight: 700; letter-spacing: 0.01em;
+    border-bottom: 1px solid var(--color-border-primary); padding-bottom: 0.3em;
+    margin: 0.75em 0 0.5em; color: var(--color-text-primary);
 }
 .s3-wysiwyg h2 {
     font-size: 1.5em; font-weight: 600; letter-spacing: 0.06em;
@@ -557,20 +707,30 @@ main {
 .s3-wysiwyg h5 { font-size: 1em; font-weight: 600; margin: 0.6em 0 0.4em; color: var(--color-text-secondary); }
 .s3-wysiwyg h6 { font-size: 0.9em; font-weight: 600; margin: 0.6em 0 0.4em; color: var(--color-text-secondary); }
 
-.s3-wysiwyg strong { font-weight: 700; color: var(--color-accent-blue); }
+.s3-wysiwyg strong { font-weight: 700; color: var(--color-text-primary); }
 .s3-wysiwyg em { font-style: italic; color: var(--color-text-primary); }
 .s3-wysiwyg del { text-decoration: line-through; color: var(--color-text-secondary); opacity: 0.7; }
 
 .s3-wysiwyg code {
     background: var(--color-bg-tertiary); color: var(--color-accent-orange);
-    padding: 0.15rem 0.4rem; border-radius: 2px; font-family: var(--font-mono);
+    padding: 0.15rem 0.4rem; border-radius: var(--panel-border-radius); font-family: var(--font-mono);
     font-size: 0.85em; border: 1px solid var(--color-border-secondary);
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.12);
 }
 .s3-wysiwyg pre {
     background: var(--color-bg-tertiary); border: 1px solid var(--color-border-primary);
-    border-radius: 2px; padding: 1rem; margin: 1em 0; overflow-x: auto; line-height: 1.5;
+    border-radius: var(--panel-border-radius); padding: 1rem; margin: 1em 0; overflow-x: auto; line-height: 1.5;
+    box-shadow: inset 0 1px 4px rgba(0,0,0,0.18);
 }
 .s3-wysiwyg pre code { background: none; border: none; padding: 0; color: var(--color-text-primary); }
+/* Preview token colors — same hues but toned down for prose reading context */
+.s3-wysiwyg pre code .tok-keyword,
+.s3-wysiwyg pre code .tok-type,
+.s3-wysiwyg pre code .tok-string,
+.s3-wysiwyg pre code .tok-number,
+.s3-wysiwyg pre code .tok-builtin,
+.s3-wysiwyg pre code .tok-operator { opacity: 0.78; }
+.s3-wysiwyg pre code .tok-comment { opacity: 0.65; }
 
 .s3-wysiwyg ul, .s3-wysiwyg ol { padding-left: 2.5em; margin: 0.8em 0; }
 .s3-wysiwyg li { margin: 0.4em 0; line-height: 1.6; }
@@ -600,7 +760,7 @@ main {
 .s3-wysiwyg a { color: var(--color-accent-blue); text-decoration: none; border-bottom: 1px dotted var(--color-accent-blue); transition: all 0.2s ease; }
 .s3-wysiwyg a:hover { border-bottom: 1px solid var(--color-accent-blue); background: var(--color-bg-tertiary); }
 
-.s3-wysiwyg img { max-width: 100%; height: auto; margin: 1em 0; border: 1px solid var(--color-border-primary); border-radius: 2px; }
+.s3-wysiwyg img { max-width: 100%; height: auto; margin: 1em 0; border: 1px solid var(--color-border-primary); border-radius: var(--panel-border-radius); }
 
 .s3-wysiwyg table { border-collapse: collapse; width: 100%; margin: 1em 0; border: 1px solid var(--color-border-primary); }
 .s3-wysiwyg thead { background: var(--color-bg-secondary); border-bottom: 2px solid var(--color-accent-blue); }
@@ -611,7 +771,7 @@ main {
 .s3-wysiwyg hr { border: none; border-top: 2px solid var(--color-border-primary); margin: 1.5em 0; height: 1px; }
 .s3-wysiwyg p { margin: 0.8em 0; line-height: 1.75; }
 .s3-wysiwyg p img {
-    max-height: 20px;
+    max-height: 24px;
     width: auto;
     max-width: 100%;
     vertical-align: middle;
@@ -627,7 +787,7 @@ main {
     font-family: var(--font-mono);
     padding: 0.1rem 0.3rem;
     border: 1px dashed var(--color-border-primary);
-    border-radius: 2px;
+    border-radius: var(--panel-border-radius);
 }
 
 /* =====================================================================
@@ -731,7 +891,7 @@ main {
 .s3-nested-json {
     background: var(--color-bg-tertiary);
     padding: 1rem;
-    border-radius: 2px;
+    border-radius: var(--panel-border-radius);
     border: 1px solid var(--color-border-primary);
     overflow-x: auto;
     max-height: 400px;
@@ -851,7 +1011,7 @@ main {
 .autosave-toggle {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 5px;
     font-size: 0.8rem;
     color: var(--color-text-secondary);
     cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -21,12 +21,12 @@
         <button class="btn" id="open-folder">Open Folder</button>
         <div id="breadcrumb"></div>
         <div class="spacer"></div>
-        <button class="btn btn-sm" id="theme-toggle" title="Toggle theme" aria-label="Toggle dark/light theme">◑</button>
         <label class="autosave-toggle" id="autosave-toggle-label">
             <input type="checkbox" id="autosave-checkbox" />
             <span id="autosave-label">autosave</span>
         </label>
         <button class="btn btn-primary" id="save-btn" disabled>Save</button>
+        <button class="btn btn-sm" id="theme-toggle" title="Toggle theme" aria-label="Toggle dark/light theme">◑</button>
     </header>
     <main>
         <aside id="sidebar">

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
         <div id="breadcrumb"></div>
         <div class="spacer"></div>
         <button class="btn btn-sm" id="theme-toggle" title="Toggle theme" aria-label="Toggle dark/light theme">◑</button>
+        <label class="autosave-toggle" id="autosave-toggle-label">
+            <input type="checkbox" id="autosave-checkbox" />
+            <span id="autosave-label">autosave</span>
+        </label>
         <button class="btn btn-primary" id="save-btn" disabled>Save</button>
     </header>
     <main>

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -616,10 +616,14 @@ function highlightCode(text, lang) {
 
 function applySyntaxHighlighting(container) {
     container.querySelectorAll('pre > code').forEach(code => {
-        const pre = code.parentElement;
-        const lang = getCodeLang(pre);
-        const text = code.textContent;
-        code.innerHTML = highlightCode(text, lang);
+        try {
+            const pre = code.parentElement;
+            const lang = getCodeLang(pre);
+            const text = code.textContent;
+            code.innerHTML = highlightCode(text, lang);
+        } catch (e) {
+            console.error('Syntax highlight error:', e);
+        }
     });
 }
 

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -34,6 +34,9 @@ const state = {
     treeviewCollapsed: new Set(),
     // Navigation: [{handle, name}]
     pathStack: [],
+    // Autosave
+    autosaveEnabled: false,
+    autosaveTimer: null,
 };
 
 // =========================================================================
@@ -340,6 +343,15 @@ async function openFile(fileHandle, filename) {
     const ext = getExtension(filename);
     determineInitialMode(ext, content);
     renderEditor(content, filename);
+
+    // Enable autosave controls
+    const autosaveCheckbox = document.getElementById('autosave-checkbox');
+    const autosaveToggleLabel = document.getElementById('autosave-toggle-label');
+    if (autosaveCheckbox) {
+        autosaveCheckbox.disabled = false;
+        autosaveCheckbox.checked = state.autosaveEnabled;
+    }
+    if (autosaveToggleLabel) autosaveToggleLabel.style.opacity = '';
 }
 
 function determineInitialMode(ext, content) {
@@ -448,6 +460,206 @@ async function resolveLocalImages(container) {
     }
 }
 
+// =========================================================================
+// Syntax Highlighting
+// =========================================================================
+
+function getCodeLang(pre) {
+    const md = pre.getAttribute('data-md') || '';
+    const match = md.match(/^```(\w+)/);
+    return match ? match[1].toLowerCase() : '';
+}
+
+function getHighlightRules(lang) {
+    const comment = (pattern) => ({ regex: pattern, type: 'comment' });
+    const str = (pattern) => ({ regex: pattern, type: 'string' });
+    const num = { regex: /\b\d+(\.\d+)?([eE][+-]?\d+)?\b/y, type: 'number' };
+    const op = { regex: /[+\-*/%&|^~<>!=?:;,.()[\]{}]+/y, type: 'operator' };
+
+    switch (lang) {
+        case 'js': case 'javascript': case 'ts': case 'typescript': case 'jsx': case 'tsx':
+            return [
+                comment(/\/\/[^\n]*/y),
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/`(?:[^`\\]|\\.)*`/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /\b(break|case|catch|class|const|continue|debugger|default|delete|do|else|export|extends|finally|for|function|if|import|in|instanceof|let|new|of|return|static|super|switch|this|throw|try|typeof|var|void|while|with|yield|async|await)\b/y, type: 'keyword' },
+                { regex: /\b(Array|Boolean|Date|Error|Function|Map|Number|Object|Promise|RegExp|Set|String|Symbol|WeakMap|WeakSet|JSON|Math|console|document|window|undefined|null|true|false|NaN|Infinity)\b/y, type: 'type' },
+                num, op,
+            ];
+        case 'go':
+            return [
+                comment(/\/\/[^\n]*/y),
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/`(?:[^`])*`/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /\b(break|case|chan|const|continue|default|defer|else|fallthrough|for|func|go|goto|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b/y, type: 'keyword' },
+                { regex: /\b(bool|byte|complex64|complex128|error|float32|float64|int|int8|int16|int32|int64|rune|string|uint|uint8|uint16|uint32|uint64|uintptr|true|false|nil|iota|append|cap|close|copy|delete|len|make|new|panic|print|println|recover)\b/y, type: 'type' },
+                num, op,
+            ];
+        case 'py': case 'python':
+            return [
+                comment(/#[^\n]*/y),
+                str(/"""[\s\S]*?"""/y),
+                str(/'''[\s\S]*?'''/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /\b(and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\b/y, type: 'keyword' },
+                { regex: /\b(True|False|None|int|float|str|list|dict|set|tuple|bool|type|object|super|print|len|range|enumerate|zip|map|filter|sorted|reversed|open|input)\b/y, type: 'builtin' },
+                num, op,
+            ];
+        case 'rs': case 'rust':
+            return [
+                comment(/\/\/[^\n]*/y),
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                { regex: /\b(as|async|await|break|const|continue|crate|dyn|else|enum|extern|false|fn|for|if|impl|in|let|loop|match|mod|move|mut|pub|ref|return|self|Self|static|struct|super|trait|true|type|unsafe|use|where|while)\b/y, type: 'keyword' },
+                { regex: /\b(bool|char|f32|f64|i8|i16|i32|i64|i128|isize|str|u8|u16|u32|u64|u128|usize|String|Vec|Option|Result|Box|Rc|Arc|HashMap|HashSet)\b/y, type: 'type' },
+                num, op,
+            ];
+        case 'sh': case 'bash': case 'shell': case 'zsh':
+            return [
+                comment(/#[^\n]*/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'[^']*'/y),
+                { regex: /\b(if|then|else|elif|fi|for|while|do|done|case|esac|in|function|return|exit|echo|export|source|local|readonly|shift|unset|set|trap)\b/y, type: 'keyword' },
+                num, op,
+            ];
+        case 'json':
+            return [
+                str(/"(?:[^"\\]|\\.)*"/y),
+                { regex: /\b(true|false|null)\b/y, type: 'keyword' },
+                num, op,
+            ];
+        case 'css':
+            return [
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /\b(important|auto|none|inherit|initial|unset|normal|bold|italic|solid|dashed|dotted|left|right|center|top|bottom|flex|grid|block|inline|absolute|relative|fixed|sticky|hidden|visible)\b/y, type: 'keyword' },
+                { regex: /\b\d+(\.\d+)?(px|em|rem|vh|vw|%|pt|cm|mm|s|ms)?\b/y, type: 'number' },
+                { regex: /#[0-9a-fA-F]{3,6}\b/y, type: 'string' },
+                op,
+            ];
+        case 'html': case 'xml':
+            return [
+                comment(/<!--[\s\S]*?-->/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /<\/?[a-zA-Z][a-zA-Z0-9-]*/y, type: 'keyword' },
+                op,
+            ];
+        case 'yaml': case 'yml':
+            return [
+                comment(/#[^\n]*/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'[^']*'/y),
+                { regex: /\b(true|false|null|yes|no|on|off)\b/y, type: 'keyword' },
+                num, op,
+            ];
+        default:
+            return [
+                comment(/\/\/[^\n]*/y),
+                comment(/#[^\n]*/y),
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                num, op,
+            ];
+    }
+}
+
+function tokenize(code, rules) {
+    const tokens = [];
+    let i = 0;
+    const len = code.length;
+
+    while (i < len) {
+        let matched = false;
+        for (const rule of rules) {
+            rule.regex.lastIndex = i;
+            const m = rule.regex.exec(code);
+            if (m && m.index === i) {
+                tokens.push({ type: rule.type, value: m[0] });
+                i += m[0].length;
+                matched = true;
+                break;
+            }
+        }
+        if (!matched) {
+            const last = tokens[tokens.length - 1];
+            if (last && last.type === 'plain') {
+                last.value += code[i];
+            } else {
+                tokens.push({ type: 'plain', value: code[i] });
+            }
+            i++;
+        }
+    }
+    return tokens;
+}
+
+function highlightCode(text, lang) {
+    const rules = getHighlightRules(lang);
+    const tokens = tokenize(text, rules);
+    return tokens.map(t => {
+        const escaped = t.value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        if (t.type === 'plain') return escaped;
+        return `<span class="tok-${t.type}">${escaped}</span>`;
+    }).join('');
+}
+
+function applySyntaxHighlighting(container) {
+    container.querySelectorAll('pre > code').forEach(code => {
+        const pre = code.parentElement;
+        const lang = getCodeLang(pre);
+        const text = code.textContent;
+        code.innerHTML = highlightCode(text, lang);
+    });
+}
+
+// =========================================================================
+// Autosave
+// =========================================================================
+
+function loadAutosavePref() {
+    const saved = localStorage.getItem('hotnote2-autosave');
+    return saved !== null ? saved === 'true' : true; // default enabled
+}
+
+function saveAutosavePref(enabled) {
+    localStorage.setItem('hotnote2-autosave', String(enabled));
+}
+
+function startAutosaveTimer() {
+    if (state.autosaveTimer) clearTimeout(state.autosaveTimer);
+    state.autosaveTimer = setTimeout(() => {
+        state.autosaveTimer = null;
+        if (state.isDirty && state.currentFileHandle && state.autosaveEnabled) {
+            saveFile(true);
+        }
+    }, 2000);
+}
+
+function animateAutosaveLabel() {
+    const label = document.getElementById('autosave-label');
+    if (!label) return;
+    label.textContent = 'saved';
+    label.classList.remove('fade-out', 'hidden');
+    setTimeout(() => {
+        label.classList.add('fade-out');
+        setTimeout(() => {
+            label.textContent = 'autosave';
+            label.classList.remove('fade-out');
+        }, 500);
+    }, 1500);
+}
+
 function switchToMode(mode, content) {
     state.editorMode = mode;
 
@@ -480,6 +692,7 @@ function switchToMode(mode, content) {
                 wysiwyg.textContent = currentContent;
             }
             resolveLocalImages(wysiwyg).catch(console.error);
+            applySyntaxHighlighting(wysiwyg);
             break;
 
         case 'datasheet': {
@@ -537,13 +750,19 @@ function clearEditor() {
         emptyState.innerHTML = '<h2>No file open</h2><p>Use <b>Open Folder</b> to browse local files.</p>';
         editorArea.appendChild(emptyState);
     }
+
+    // Disable autosave controls when no file is open
+    const autosaveCheckbox = document.getElementById('autosave-checkbox');
+    const autosaveToggleLabel = document.getElementById('autosave-toggle-label');
+    if (autosaveCheckbox) autosaveCheckbox.disabled = true;
+    if (autosaveToggleLabel) autosaveToggleLabel.style.opacity = '0.4';
 }
 
 // =========================================================================
 // Save
 // =========================================================================
 
-async function saveFile() {
+async function saveFile(silent = false) {
     if (!state.currentFileHandle) return;
     const textarea = document.getElementById('source-editor');
     try {
@@ -552,8 +771,10 @@ async function saveFile() {
         updateTitle();
         const saveBtn = document.getElementById('save-btn');
         if (saveBtn) { saveBtn.classList.remove('dirty'); saveBtn.disabled = true; }
+        if (silent) animateAutosaveLabel();
     } catch (err) {
-        alert(`Failed to save: ${err.message}`);
+        if (!silent) alert(`Failed to save: ${err.message}`);
+        else console.error('Autosave failed:', err);
     }
 }
 
@@ -564,6 +785,7 @@ function setDirty() {
         const saveBtn = document.getElementById('save-btn');
         if (saveBtn) { saveBtn.classList.add('dirty'); saveBtn.disabled = false; }
     }
+    startAutosaveTimer();
 }
 
 function updateTitle() {
@@ -1062,6 +1284,20 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('resize-handle').style.display = 'none';
     clearEditor();
     updateTitle();
+
+    // Autosave init
+    state.autosaveEnabled = loadAutosavePref();
+    const autosaveCheckbox = document.getElementById('autosave-checkbox');
+    const autosaveToggleLabel = document.getElementById('autosave-toggle-label');
+    if (autosaveCheckbox) {
+        autosaveCheckbox.addEventListener('change', (e) => {
+            state.autosaveEnabled = e.target.checked;
+            saveAutosavePref(e.target.checked);
+        });
+    }
+    // Initially disabled until a file is open (clearEditor will set these too, but explicit here)
+    if (autosaveToggleLabel) autosaveToggleLabel.style.opacity = '0.4';
+    if (autosaveCheckbox) autosaveCheckbox.disabled = true;
 
     // Check if File System Access API is available
     if (!window.showDirectoryPicker) {

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -14,6 +14,12 @@ const TEXT_EXTENSIONS = new Set([
     'graphql', 'proto', 'tf', 'hcl', 'log', 'csv',
 ]);
 
+const CODE_EXTENSIONS = new Set([
+    'js', 'ts', 'jsx', 'tsx', 'go', 'py', 'rb', 'rs', 'css', 'scss',
+    'html', 'htm', 'xml', 'sh', 'bash', 'zsh', 'yaml', 'yml',
+    'toml', 'sql', 'graphql', 'proto', 'tf', 'hcl', 'conf', 'ini', 'cfg',
+]);
+
 // =========================================================================
 // State
 // =========================================================================
@@ -24,7 +30,7 @@ const state = {
     currentFileHandle: null,
     currentFilename: '',
     isDirty: false,
-    editorMode: 'source', // 'source' | 'wysiwyg' | 'datasheet' | 'treeview'
+    editorMode: 'source', // 'source' | 'wysiwyg' | 'highlight' | 'datasheet' | 'treeview'
     // JSON view state
     datasheetData: null,
     datasheetSchema: null,
@@ -379,9 +385,16 @@ function determineInitialMode(ext, content) {
     // Markdown handling
     if (shouldUseWysiwygMode(ext, content)) {
         state.editorMode = 'wysiwyg';
-    } else {
-        state.editorMode = 'source';
+        return;
     }
+
+    // Code file handling — default to highlighted view
+    if (CODE_EXTENSIONS.has(ext)) {
+        state.editorMode = 'highlight';
+        return;
+    }
+
+    state.editorMode = 'source';
 }
 
 function renderEditor(content, filename) {
@@ -410,6 +423,7 @@ function updateModeToolbar() {
     const ext = getExtension(state.currentFilename);
     const isJson = ext === 'json';
     const isMd = ext === 'md';
+    const isCode = CODE_EXTENSIONS.has(ext);
 
     const ds = isJson ? detectDatasheetMode(document.getElementById('source-editor').value) : { isDatasheet: false };
     const jt = isJson ? detectJsonType(document.getElementById('source-editor').value) : { isObject: false, isArray: false };
@@ -418,6 +432,7 @@ function updateModeToolbar() {
     modeToolbar.innerHTML = `
         <button class="btn btn-sm${state.editorMode === 'source' ? ' active' : ''}" id="mode-source">Source</button>
         ${isMd ? `<button class="btn btn-sm${state.editorMode === 'wysiwyg' ? ' active' : ''}" id="mode-wysiwyg">Preview</button>` : ''}
+        ${(isCode || isJson) ? `<button class="btn btn-sm${state.editorMode === 'highlight' ? ' active' : ''}" id="mode-highlight">View</button>` : ''}
         ${(isJson && ds.isDatasheet) ? `<button class="btn btn-sm${state.editorMode === 'datasheet' ? ' active' : ''}" id="mode-datasheet">Datasheet</button>` : ''}
         ${(isJson && (jt.isObject || jt.isArray)) ? `<button class="btn btn-sm${state.editorMode === 'treeview' ? ' active' : ''}" id="mode-treeview">Tree</button>` : ''}
         <span id="filename-display" class="filename-display">${escapeHtml(state.currentFilename)}</span>
@@ -425,6 +440,7 @@ function updateModeToolbar() {
 
     document.getElementById('mode-source')?.addEventListener('click', () => switchToMode('source'));
     document.getElementById('mode-wysiwyg')?.addEventListener('click', () => switchToMode('wysiwyg'));
+    document.getElementById('mode-highlight')?.addEventListener('click', () => switchToMode('highlight'));
     document.getElementById('mode-datasheet')?.addEventListener('click', () => switchToMode('datasheet'));
     document.getElementById('mode-treeview')?.addEventListener('click', () => switchToMode('treeview'));
 }
@@ -715,6 +731,15 @@ function switchToMode(mode, content) {
             state.treeviewCollapsed = new Set();
             treeview.style.display = 'block';
             renderTreeView();
+            break;
+        }
+
+        case 'highlight': {
+            const lang = getExtension(state.currentFilename);
+            wysiwyg.style.display = 'block';
+            wysiwyg.className = 'code-highlight-view';
+            wysiwyg.contentEditable = 'false';
+            wysiwyg.innerHTML = `<pre class="code-highlight-pre"><code>${highlightCode(currentContent, lang)}</code></pre>`;
             break;
         }
     }


### PR DESCRIPTION
## Summary
- Introduces 3-level elevation system with `box-shadow` tokens (`--shadow-sm`, `--shadow-md`, `--shadow-lg`, `--highlight-top`, `--focus-glow`) across all theme blocks
- Header, sidebar, and mode-toolbar get Level 1 chrome shadows with proper z-index layering
- Buttons get subtle raised appearance with top highlight, depress on `:active`, flush for `.active`/`.btn-primary`
- Modal gets large floating shadow for clear Level 3 overlay elevation
- Line numbers, `<pre>` blocks, and inline `<code>` get inset recessed shadows for depth
- Active file entry gets left-border accent via `inset 2px 0 0` box-shadow
- Input focus ring gains themed `--focus-glow` halo
- Syntax token colors boosted to vivid palette: magenta/cyan/lavender (dark), crimson/teal/violet (light)
- Markdown preview code blocks share the same token colors at 78% opacity for a softer reading context

## Test plan
- [ ] Open index.html in Chrome — header casts a visible shadow down onto main content
- [ ] Sidebar casts rightward shadow onto editor pane
- [ ] Buttons look subtly raised; feel pressed on click; inverted (active/primary) are flush
- [ ] Modal floats clearly above the overlay backdrop
- [ ] Line numbers look recessed vs editor content
- [ ] Active file in sidebar has a left accent bar
- [ ] Source editor token colors are vivid and clearly distinguishable
- [ ] Preview mode code blocks show the same colors at lighter intensity
- [ ] Both dark and light themes look coherent

🤖 Generated with [Claude Code](https://claude.com/claude-code)