### PR TITLE
Enable word wrap in source editor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,6 +23,14 @@ html[data-theme="dark"] {
     --header-height: 48px;
     --sidebar-width: 240px;
     --resize-handle-width: 5px;
+    /* Syntax token colors */
+    --tok-keyword: #ffffff;
+    --tok-type:    #d0d0d0;
+    --tok-string:  #a8a8a8;
+    --tok-number:  #909090;
+    --tok-comment: #505050;
+    --tok-builtin: #c0c0c0;
+    --tok-operator: #e8e8e8;
 }
 
 /* Light theme */
@@ -44,6 +52,14 @@ html[data-theme="light"] {
     --header-height: 48px;
     --sidebar-width: 240px;
     --resize-handle-width: 5px;
+    /* Syntax token colors */
+    --tok-keyword: #000000;
+    --tok-type:    #222222;
+    --tok-string:  #555555;
+    --tok-number:  #666666;
+    --tok-comment: #999999;
+    --tok-builtin: #333333;
+    --tok-operator: #111111;
 }
 
 /* System preference fallback (when no data-theme set yet) */
@@ -61,6 +77,13 @@ html[data-theme="light"] {
         --color-accent-green: #444444;
         --color-accent-orange: #555555;
         --color-accent-red: #222222;
+        --tok-keyword: #000000;
+        --tok-type:    #222222;
+        --tok-string:  #555555;
+        --tok-number:  #666666;
+        --tok-comment: #999999;
+        --tok-builtin: #333333;
+        --tok-operator: #111111;
     }
 }
 
@@ -771,3 +794,40 @@ main {
     letter-spacing: 0.05em;
 }
 .tree-datasheet-link:hover { text-decoration: underline; }
+
+/* =====================================================================
+   Syntax Highlighting Token Classes
+   ===================================================================== */
+.tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
+.tok-type     { color: var(--tok-type); }
+.tok-string   { color: var(--tok-string); }
+.tok-number   { color: var(--tok-number); }
+.tok-comment  { color: var(--tok-comment); font-style: italic; }
+.tok-builtin  { color: var(--tok-builtin); }
+.tok-operator { color: var(--tok-operator); }
+
+/* =====================================================================
+   Autosave Toggle
+   ===================================================================== */
+.autosave-toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    user-select: none;
+}
+.autosave-toggle input {
+    accent-color: var(--color-text-primary);
+    cursor: pointer;
+}
+#autosave-label {
+    transition: opacity 0.5s ease, transform 0.5s ease;
+    white-space: nowrap;
+}
+#autosave-label.fade-out {
+    opacity: 0;
+    transform: translateX(-8px);
+}
+#autosave-label.hidden { display: none; }

--- a/css/style.css
+++ b/css/style.css
@@ -23,14 +23,14 @@ html[data-theme="dark"] {
     --header-height: 48px;
     --sidebar-width: 240px;
     --resize-handle-width: 5px;
-    /* Syntax token colors */
-    --tok-keyword: #ffffff;
-    --tok-type:    #d0d0d0;
-    --tok-string:  #a8a8a8;
-    --tok-number:  #909090;
-    --tok-comment: #505050;
-    --tok-builtin: #c0c0c0;
-    --tok-operator: #e8e8e8;
+    /* Syntax token colors — matches hotnote brand theme (dark) */
+    --tok-keyword: #e8bcd4;    /* muted pink — keywords, types, class names */
+    --tok-type:    #e8bcd4;    /* muted pink */
+    --tok-string:  #b8e5f2;    /* muted cyan — strings, variables, properties */
+    --tok-number:  #c8bce8;    /* muted purple — numbers, booleans, operators */
+    --tok-comment: #888888;    /* gray — comments */
+    --tok-builtin: #b8e5f2;    /* muted cyan — builtins */
+    --tok-operator: #c8bce8;   /* muted purple */
 }
 
 /* Light theme */
@@ -52,14 +52,14 @@ html[data-theme="light"] {
     --header-height: 48px;
     --sidebar-width: 240px;
     --resize-handle-width: 5px;
-    /* Syntax token colors */
-    --tok-keyword: #000000;
-    --tok-type:    #222222;
-    --tok-string:  #555555;
-    --tok-number:  #666666;
-    --tok-comment: #999999;
-    --tok-builtin: #333333;
-    --tok-operator: #111111;
+    /* Syntax token colors — matches hotnote brand theme (light) */
+    --tok-keyword: #a65580;    /* darker muted pink — keywords, types, class names */
+    --tok-type:    #a65580;    /* darker muted pink */
+    --tok-string:  #5a9cb8;    /* darker muted cyan — strings, variables, properties */
+    --tok-number:  #7a65ad;    /* darker muted purple — numbers, booleans, operators */
+    --tok-comment: #999999;    /* gray — comments */
+    --tok-builtin: #5a9cb8;    /* darker muted cyan — builtins */
+    --tok-operator: #7a65ad;   /* darker muted purple */
 }
 
 /* System preference fallback (when no data-theme set yet) */
@@ -77,13 +77,13 @@ html[data-theme="light"] {
         --color-accent-green: #444444;
         --color-accent-orange: #555555;
         --color-accent-red: #222222;
-        --tok-keyword: #000000;
-        --tok-type:    #222222;
-        --tok-string:  #555555;
-        --tok-number:  #666666;
+        --tok-keyword: #a65580;
+        --tok-type:    #a65580;
+        --tok-string:  #5a9cb8;
+        --tok-number:  #7a65ad;
         --tok-comment: #999999;
-        --tok-builtin: #333333;
-        --tok-operator: #111111;
+        --tok-builtin: #5a9cb8;
+        --tok-operator: #7a65ad;
     }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -178,7 +178,7 @@ header {
 .logo {
     font-family: var(--font-mono);
     font-size: 1.08rem;
-    font-weight: 700;
+    font-weight: 900;
     letter-spacing: 0.12em;
     text-transform: uppercase;
     white-space: nowrap;
@@ -188,6 +188,7 @@ header {
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
+    -webkit-text-stroke: 0.5px rgba(255,255,255,0.15);
     color: transparent;
     filter:
         drop-shadow(0 0 6px rgba(255, 45, 150, 0.50))
@@ -200,10 +201,10 @@ html[data-theme="light"] .logo {
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
+    -webkit-text-stroke: 0.5px rgba(0,0,0,0.12);
     filter:
-        drop-shadow(0 0 4px rgba(233, 30, 140, 0.40))
-        drop-shadow(0 0 10px rgba(0, 212, 255, 0.28))
-        drop-shadow(0 0 18px rgba(233, 30, 140, 0.20));
+        drop-shadow(0 1px 2px rgba(0, 0, 0, 0.30))
+        drop-shadow(0 2px 8px rgba(0, 0, 0, 0.18));
 }
 
 @media (prefers-color-scheme: light) {
@@ -212,10 +213,10 @@ html[data-theme="light"] .logo {
         -webkit-background-clip: text;
         background-clip: text;
         -webkit-text-fill-color: transparent;
+        -webkit-text-stroke: 0.5px rgba(0,0,0,0.12);
         filter:
-            drop-shadow(0 0 4px rgba(233, 30, 140, 0.40))
-            drop-shadow(0 0 10px rgba(0, 212, 255, 0.28))
-            drop-shadow(0 0 18px rgba(233, 30, 140, 0.20));
+            drop-shadow(0 1px 2px rgba(0, 0, 0, 0.30))
+            drop-shadow(0 2px 8px rgba(0, 0, 0, 0.18));
     }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -33,6 +33,9 @@ html[data-theme="dark"] {
     --tok-operator: #b098e8;
     --color-bg-navbar:  #252525;  /* lighter than secondary — header elevation */
     --color-bg-toolbar: #111111;  /* darker than secondary — sub-toolbar recess */
+    --color-btn-bg:     #1e1b28;  /* muted lavender-gray — button face */
+    --color-btn-border: #3a3254;  /* slightly lighter lavender-gray — button edge */
+    --btn-border-radius: 5px;
     --shadow-sm:        0 1px 3px rgba(0,0,0,0.30), 0 1px 1px rgba(0,0,0,0.18);
     --shadow-md:        0 2px 8px rgba(0,0,0,0.35), 0 1px 3px rgba(0,0,0,0.20);
     --shadow-lg:        0 12px 40px rgba(0,0,0,0.55), 0 4px 14px rgba(0,0,0,0.30);
@@ -69,6 +72,9 @@ html[data-theme="light"] {
     --tok-operator: #3a1888;
     --color-bg-navbar:  #f9f9f9;  /* lighter than secondary — header elevation */
     --color-bg-toolbar: #e6e6e6;  /* darker than secondary — sub-toolbar recess */
+    --color-btn-bg:     #eeeaf6;  /* muted lavender-tint — button face */
+    --color-btn-border: #c8bce0;  /* medium lavender-gray — button edge */
+    --btn-border-radius: 5px;
     --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
     --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
     --shadow-lg:        0 12px 40px rgba(0,0,0,0.20), 0 4px 14px rgba(0,0,0,0.10);
@@ -100,6 +106,9 @@ html[data-theme="light"] {
         --tok-operator: #3a1888;
         --color-bg-navbar:  #f9f9f9;
         --color-bg-toolbar: #e6e6e6;
+        --color-btn-bg:     #eeeaf6;
+        --color-btn-border: #c8bce0;
+        --btn-border-radius: 5px;
         --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
         --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
         --shadow-lg:        0 12px 40px rgba(0,0,0,0.20), 0 4px 14px rgba(0,0,0,0.10);
@@ -581,11 +590,11 @@ main {
     font-weight: 500;
     font-family: inherit;
     letter-spacing: 0.02em;
-    border: 1px solid var(--color-border-primary);
-    background: var(--color-bg-tertiary);
+    border: 1px solid var(--color-btn-border);
+    background: var(--color-btn-bg);
     color: var(--color-text-primary);
     cursor: pointer;
-    border-radius: var(--panel-border-radius);
+    border-radius: var(--btn-border-radius);
     white-space: nowrap;
     transition: background 0.12s, border-color 0.12s, color 0.12s, box-shadow 0.12s;
     user-select: none;
@@ -593,8 +602,8 @@ main {
 }
 
 .btn:hover:not(:disabled) {
-    background: var(--color-bg-primary);
-    border-color: var(--color-text-secondary);
+    background: var(--color-bg-tertiary);
+    border-color: var(--color-btn-border);
     box-shadow: var(--shadow-sm);
 }
 
@@ -758,14 +767,6 @@ main {
     box-shadow: inset 0 1px 4px rgba(0,0,0,0.18);
 }
 .s3-wysiwyg pre code { background: none; border: none; padding: 0; color: var(--color-text-primary); }
-/* Preview token colors — same hues but toned down for prose reading context */
-.s3-wysiwyg pre code .tok-keyword,
-.s3-wysiwyg pre code .tok-type,
-.s3-wysiwyg pre code .tok-string,
-.s3-wysiwyg pre code .tok-number,
-.s3-wysiwyg pre code .tok-builtin,
-.s3-wysiwyg pre code .tok-operator { opacity: 0.78; }
-.s3-wysiwyg pre code .tok-comment { opacity: 0.65; }
 
 .s3-wysiwyg ul, .s3-wysiwyg ol { padding-left: 2.5em; margin: 0.8em 0; }
 .s3-wysiwyg li { margin: 0.4em 0; line-height: 1.6; }

--- a/css/style.css
+++ b/css/style.css
@@ -549,6 +549,24 @@ main {
     display: none;
 }
 
+/* Image viewer */
+#image-viewer {
+    flex: 1;
+    overflow: auto;
+    background: var(--color-bg-primary);
+    display: none;
+    justify-content: center;
+    padding: 2rem;
+}
+
+#image-viewer img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    border: 1px solid var(--color-border-primary);
+    box-shadow: var(--shadow-md);
+}
+
 /* =====================================================================
    Buttons
    ===================================================================== */
@@ -788,12 +806,12 @@ main {
 .s3-wysiwyg hr { border: none; border-top: 2px solid var(--color-border-primary); margin: 1.5em 0; height: 1px; }
 .s3-wysiwyg p { margin: 0.8em 0; line-height: 1.75; }
 .s3-wysiwyg p img {
-    max-height: 24px;
-    width: auto;
+    display: block;
+    width: 100%;
+    height: auto;
     max-width: 100%;
-    vertical-align: middle;
-    margin: 0 0.125rem;
-    border: none;
+    margin: 0.75em 0;
+    border: 1px solid var(--color-border-primary);
 }
 
 .img-placeholder {
@@ -944,9 +962,9 @@ main {
 }
 .tree-toggle:hover { color: var(--color-text-primary); }
 
-.tree-key { color: var(--color-text-primary); margin-right: 0.25rem; }
-.tree-bracket { color: var(--color-text-secondary); margin: 0 0.25rem; }
-.tree-count { color: var(--color-text-secondary); font-style: italic; font-size: 0.55rem; }
+.tree-key { color: var(--tok-string); margin-right: 0.25rem; }
+.tree-bracket { color: var(--tok-operator); margin: 0 0.25rem; }
+.tree-count { color: var(--color-text-tertiary); font-style: italic; font-size: 0.55rem; }
 
 .tree-children {
     margin-left: 1.5rem;
@@ -954,11 +972,11 @@ main {
     padding-left: 0.5rem;
 }
 
-.tree-string { color: var(--color-accent-green); }
-.tree-number { color: var(--color-accent-blue); }
-.tree-boolean { color: var(--color-accent-orange); }
-.tree-null { color: var(--color-text-secondary); font-style: italic; }
-.tree-undefined { color: var(--color-text-secondary); font-style: italic; }
+.tree-string { color: var(--tok-string); }
+.tree-number { color: var(--tok-number); }
+.tree-boolean { color: var(--tok-keyword); }
+.tree-null { color: var(--tok-comment); font-style: italic; }
+.tree-undefined { color: var(--tok-comment); font-style: italic; }
 .tree-unknown { color: var(--color-accent-red); }
 
 .tree-datasheet-link {

--- a/css/style.css
+++ b/css/style.css
@@ -35,6 +35,7 @@ html[data-theme="dark"] {
     --color-bg-toolbar: #111111;  /* darker than secondary — sub-toolbar recess */
     --color-btn-bg:     #1e1b28;  /* muted lavender-gray — button face */
     --color-btn-border: #3a3254;  /* slightly lighter lavender-gray — button edge */
+    --color-logo:       #9060a0;  /* muted magenta — logo text */
     --btn-border-radius: 5px;
     --shadow-sm:        0 1px 3px rgba(0,0,0,0.30), 0 1px 1px rgba(0,0,0,0.18);
     --shadow-md:        0 2px 8px rgba(0,0,0,0.35), 0 1px 3px rgba(0,0,0,0.20);
@@ -74,6 +75,7 @@ html[data-theme="light"] {
     --color-bg-toolbar: #e6e6e6;  /* darker than secondary — sub-toolbar recess */
     --color-btn-bg:     #eeeaf6;  /* muted lavender-tint — button face */
     --color-btn-border: #c8bce0;  /* medium lavender-gray — button edge */
+    --color-logo:       #7a3878;  /* muted magenta — logo text */
     --btn-border-radius: 5px;
     --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
     --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
@@ -108,6 +110,7 @@ html[data-theme="light"] {
         --color-bg-toolbar: #e6e6e6;
         --color-btn-bg:     #eeeaf6;
         --color-btn-border: #c8bce0;
+        --color-logo:       #7a3878;
         --btn-border-radius: 5px;
         --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
         --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
@@ -165,7 +168,7 @@ body {
 header {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.25rem;
     height: var(--header-height);
     padding: 0 1rem;
     background: var(--color-bg-navbar);
@@ -177,13 +180,13 @@ header {
 
 .logo {
     font-family: var(--font-mono);
-    font-size: 0.8125rem;
+    font-size: 1.08rem;
     font-weight: 700;
-    color: var(--color-text-primary);
+    color: var(--color-logo);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     white-space: nowrap;
-    opacity: 0.9;
+    margin-right: 0.5rem;
 }
 
 #breadcrumb {
@@ -195,6 +198,7 @@ header {
     font-size: 0.8125rem;
     color: var(--color-text-secondary);
     min-width: 0;
+    margin-left: 0.5rem;
 }
 
 #breadcrumb .crumb {
@@ -739,24 +743,24 @@ main {
 .s3-wysiwyg h1 {
     font-size: 1.875em; font-weight: 700; letter-spacing: 0.01em;
     border-bottom: 1px solid var(--color-border-primary); padding-bottom: 0.3em;
-    margin: 0.75em 0 0.5em; color: var(--color-text-primary);
+    margin: 0.75em 0 0.5em; color: var(--tok-keyword);
 }
 .s3-wysiwyg h2 {
     font-size: 1.5em; font-weight: 600; letter-spacing: 0.06em;
     border-bottom: 1px solid var(--color-border-secondary); padding-bottom: 0.3em;
-    margin: 0.9em 0 0.5em; color: var(--color-text-primary);
+    margin: 0.9em 0 0.5em; color: var(--tok-keyword);
 }
-.s3-wysiwyg h3 { font-size: 1.25em; font-weight: 600; margin: 0.8em 0 0.4em; color: var(--color-text-primary); }
-.s3-wysiwyg h4 { font-size: 1.1em; font-weight: 600; margin: 0.7em 0 0.4em; color: var(--color-text-primary); }
-.s3-wysiwyg h5 { font-size: 1em; font-weight: 600; margin: 0.6em 0 0.4em; color: var(--color-text-secondary); }
-.s3-wysiwyg h6 { font-size: 0.9em; font-weight: 600; margin: 0.6em 0 0.4em; color: var(--color-text-secondary); }
+.s3-wysiwyg h3 { font-size: 1.25em; font-weight: 600; margin: 0.8em 0 0.4em; color: var(--tok-keyword); }
+.s3-wysiwyg h4 { font-size: 1.1em; font-weight: 600; margin: 0.7em 0 0.4em; color: var(--tok-type); }
+.s3-wysiwyg h5 { font-size: 1em; font-weight: 600; margin: 0.6em 0 0.4em; color: var(--tok-comment); }
+.s3-wysiwyg h6 { font-size: 0.9em; font-weight: 600; margin: 0.6em 0 0.4em; color: var(--tok-comment); }
 
-.s3-wysiwyg strong { font-weight: 700; color: var(--color-text-primary); }
-.s3-wysiwyg em { font-style: italic; color: var(--color-text-primary); }
-.s3-wysiwyg del { text-decoration: line-through; color: var(--color-text-secondary); opacity: 0.7; }
+.s3-wysiwyg strong { font-weight: 700; color: var(--tok-type); }
+.s3-wysiwyg em { font-style: italic; color: var(--tok-string); }
+.s3-wysiwyg del { text-decoration: line-through; color: var(--tok-comment); opacity: 0.7; }
 
 .s3-wysiwyg code {
-    background: var(--color-bg-tertiary); color: var(--color-accent-orange);
+    background: var(--color-bg-tertiary); color: var(--tok-string);
     padding: 0.15rem 0.4rem; border-radius: var(--panel-border-radius); font-family: var(--font-mono);
     font-size: 0.85em; border: 1px solid var(--color-border-secondary);
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.12);
@@ -770,12 +774,12 @@ main {
 
 .s3-wysiwyg ul, .s3-wysiwyg ol { padding-left: 2.5em; margin: 0.8em 0; }
 .s3-wysiwyg li { margin: 0.4em 0; line-height: 1.6; }
-.s3-wysiwyg ul li::marker { color: var(--color-accent-blue); }
-.s3-wysiwyg ol li::marker { color: var(--color-accent-blue); font-weight: 600; }
+.s3-wysiwyg ul li::marker { color: var(--tok-operator); }
+.s3-wysiwyg ol li::marker { color: var(--tok-number); font-weight: 600; }
 
 .s3-wysiwyg blockquote {
-    border-left: 3px solid var(--color-accent-blue); padding-left: 1.2rem;
-    margin: 1em 0; color: var(--color-text-secondary); font-style: italic;
+    border-left: 3px solid var(--tok-comment); padding-left: 1.2rem;
+    margin: 1em 0; color: var(--tok-comment); font-style: italic;
     background: var(--color-bg-tertiary); padding-top: 0.5em; padding-bottom: 0.5em;
 }
 
@@ -793,14 +797,14 @@ main {
 .s3-wysiwyg .markdown-alert-caution { border-left-color: var(--color-accent-red); }
 .s3-wysiwyg .markdown-alert-caution .markdown-alert-title { color: var(--color-accent-red); }
 
-.s3-wysiwyg a { color: var(--color-accent-blue); text-decoration: none; border-bottom: 1px dotted var(--color-accent-blue); transition: all 0.2s ease; }
-.s3-wysiwyg a:hover { border-bottom: 1px solid var(--color-accent-blue); background: var(--color-bg-tertiary); }
+.s3-wysiwyg a { color: var(--tok-builtin); text-decoration: none; border-bottom: 1px dotted var(--tok-builtin); transition: all 0.2s ease; }
+.s3-wysiwyg a:hover { border-bottom: 1px solid var(--tok-builtin); background: var(--color-bg-tertiary); }
 
 .s3-wysiwyg img { max-width: 100%; height: auto; margin: 1em 0; border: 1px solid var(--color-border-primary); border-radius: var(--panel-border-radius); }
 
 .s3-wysiwyg table { border-collapse: collapse; width: 100%; margin: 1em 0; border: 1px solid var(--color-border-primary); }
-.s3-wysiwyg thead { background: var(--color-bg-secondary); border-bottom: 2px solid var(--color-accent-blue); }
-.s3-wysiwyg th { padding: 0.75rem; text-align: left; font-weight: 600; color: var(--color-accent-blue); border: 1px solid var(--color-border-primary); }
+.s3-wysiwyg thead { background: var(--color-bg-secondary); border-bottom: 2px solid var(--tok-keyword); }
+.s3-wysiwyg th { padding: 0.75rem; text-align: left; font-weight: 600; color: var(--tok-keyword); border: 1px solid var(--color-border-primary); }
 .s3-wysiwyg td { padding: 0.65rem 0.75rem; border: 1px solid var(--color-border-primary); }
 .s3-wysiwyg tbody tr:hover { background: var(--color-bg-secondary); }
 

--- a/css/style.css
+++ b/css/style.css
@@ -808,6 +808,44 @@ main {
 .s3-wysiwyg pre code .tok-operator { color: var(--tok-operator); }
 
 /* =====================================================================
+   Code Highlight View (standalone code file viewer)
+   ===================================================================== */
+.code-highlight-view {
+    flex: 1;
+    overflow: auto;
+    background: var(--color-bg-primary);
+    padding: 0;
+}
+
+.code-highlight-pre {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    white-space: pre;
+    min-height: 100%;
+    box-sizing: border-box;
+    color: var(--color-text-primary);
+}
+
+.code-highlight-pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+}
+
+.code-highlight-pre .tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
+.code-highlight-pre .tok-type     { color: var(--tok-type); }
+.code-highlight-pre .tok-string   { color: var(--tok-string); }
+.code-highlight-pre .tok-number   { color: var(--tok-number); }
+.code-highlight-pre .tok-comment  { color: var(--tok-comment); font-style: italic; }
+.code-highlight-pre .tok-builtin  { color: var(--tok-builtin); }
+.code-highlight-pre .tok-operator { color: var(--tok-operator); }
+
+/* =====================================================================
    Autosave Toggle
    ===================================================================== */
 .autosave-toggle {

--- a/css/style.css
+++ b/css/style.css
@@ -35,7 +35,6 @@ html[data-theme="dark"] {
     --color-bg-toolbar: #111111;  /* darker than secondary — sub-toolbar recess */
     --color-btn-bg:     #1e1b28;  /* muted lavender-gray — button face */
     --color-btn-border: #3a3254;  /* slightly lighter lavender-gray — button edge */
-    --color-logo:       #9060a0;  /* muted magenta — logo text */
     --btn-border-radius: 5px;
     --shadow-sm:        0 1px 3px rgba(0,0,0,0.30), 0 1px 1px rgba(0,0,0,0.18);
     --shadow-md:        0 2px 8px rgba(0,0,0,0.35), 0 1px 3px rgba(0,0,0,0.20);
@@ -75,7 +74,6 @@ html[data-theme="light"] {
     --color-bg-toolbar: #e6e6e6;  /* darker than secondary — sub-toolbar recess */
     --color-btn-bg:     #eeeaf6;  /* muted lavender-tint — button face */
     --color-btn-border: #c8bce0;  /* medium lavender-gray — button edge */
-    --color-logo:       #7a3878;  /* muted magenta — logo text */
     --btn-border-radius: 5px;
     --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
     --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
@@ -110,7 +108,6 @@ html[data-theme="light"] {
         --color-bg-toolbar: #e6e6e6;
         --color-btn-bg:     #eeeaf6;
         --color-btn-border: #c8bce0;
-        --color-logo:       #7a3878;
         --btn-border-radius: 5px;
         --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
         --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
@@ -182,11 +179,44 @@ header {
     font-family: var(--font-mono);
     font-size: 1.08rem;
     font-weight: 700;
-    color: var(--color-logo);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     white-space: nowrap;
     margin-right: 0.5rem;
+    /* Gradient text — dark theme default (cyan → pink) */
+    background: linear-gradient(135deg, #00d4ff 0%, #00e5ff 30%, #ff2d96 70%, #e91e8c 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    filter:
+        drop-shadow(0 0 6px rgba(255, 45, 150, 0.50))
+        drop-shadow(0 0 14px rgba(0, 212, 255, 0.35))
+        drop-shadow(0 0 26px rgba(255, 45, 150, 0.25));
+}
+
+html[data-theme="light"] .logo {
+    background: linear-gradient(135deg, #e91e8c 0%, #ff2d96 30%, #00d4ff 70%, #00b8e6 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    filter:
+        drop-shadow(0 0 4px rgba(233, 30, 140, 0.40))
+        drop-shadow(0 0 10px rgba(0, 212, 255, 0.28))
+        drop-shadow(0 0 18px rgba(233, 30, 140, 0.20));
+}
+
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme]) .logo {
+        background: linear-gradient(135deg, #e91e8c 0%, #ff2d96 30%, #00d4ff 70%, #00b8e6 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        filter:
+            drop-shadow(0 0 4px rgba(233, 30, 140, 0.40))
+            drop-shadow(0 0 10px rgba(0, 212, 255, 0.28))
+            drop-shadow(0 0 18px rgba(233, 30, 140, 0.20));
+    }
 }
 
 #breadcrumb {
@@ -810,11 +840,22 @@ main {
 
 .s3-wysiwyg hr { border: none; border-top: 2px solid var(--color-border-primary); margin: 1.5em 0; height: 1px; }
 .s3-wysiwyg p { margin: 0.8em 0; line-height: 1.75; }
+/* Images inside links / mixed inline content — keep as small badges */
 .s3-wysiwyg p img {
+    display: inline-block;
+    vertical-align: middle;
+    max-height: 1.4em;
+    width: auto;
+    border: none;
+    margin: 0 0.1rem;
+}
+
+/* Standalone images — direct child of <p>, not wrapped in a link — full width */
+.s3-wysiwyg p > img {
     display: block;
     width: 100%;
     height: auto;
-    max-width: 100%;
+    max-height: none;
     margin: 0.75em 0;
     border: 1px solid var(--color-border-primary);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -797,14 +797,15 @@ main {
 
 /* =====================================================================
    Syntax Highlighting Token Classes
+   Use .s3-wysiwyg pre code prefix to beat the color rule on <code>
    ===================================================================== */
-.tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
-.tok-type     { color: var(--tok-type); }
-.tok-string   { color: var(--tok-string); }
-.tok-number   { color: var(--tok-number); }
-.tok-comment  { color: var(--tok-comment); font-style: italic; }
-.tok-builtin  { color: var(--tok-builtin); }
-.tok-operator { color: var(--tok-operator); }
+.s3-wysiwyg pre code .tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
+.s3-wysiwyg pre code .tok-type     { color: var(--tok-type); }
+.s3-wysiwyg pre code .tok-string   { color: var(--tok-string); }
+.s3-wysiwyg pre code .tok-number   { color: var(--tok-number); }
+.s3-wysiwyg pre code .tok-comment  { color: var(--tok-comment); font-style: italic; }
+.s3-wysiwyg pre code .tok-builtin  { color: var(--tok-builtin); }
+.s3-wysiwyg pre code .tok-operator { color: var(--tok-operator); }
 
 /* =====================================================================
    Autosave Toggle

--- a/css/style.css
+++ b/css/style.css
@@ -31,6 +31,8 @@ html[data-theme="dark"] {
     --tok-comment: #666666;    /* mid gray */
     --tok-builtin: #58cce0;
     --tok-operator: #b098e8;
+    --color-bg-navbar:  #252525;  /* lighter than secondary — header elevation */
+    --color-bg-toolbar: #111111;  /* darker than secondary — sub-toolbar recess */
     --shadow-sm:        0 1px 3px rgba(0,0,0,0.30), 0 1px 1px rgba(0,0,0,0.18);
     --shadow-md:        0 2px 8px rgba(0,0,0,0.35), 0 1px 3px rgba(0,0,0,0.20);
     --shadow-lg:        0 12px 40px rgba(0,0,0,0.55), 0 4px 14px rgba(0,0,0,0.30);
@@ -65,6 +67,8 @@ html[data-theme="light"] {
     --tok-comment: #909090;    /* mid gray */
     --tok-builtin: #0a5a78;
     --tok-operator: #3a1888;
+    --color-bg-navbar:  #f9f9f9;  /* lighter than secondary — header elevation */
+    --color-bg-toolbar: #e6e6e6;  /* darker than secondary — sub-toolbar recess */
     --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
     --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
     --shadow-lg:        0 12px 40px rgba(0,0,0,0.20), 0 4px 14px rgba(0,0,0,0.10);
@@ -94,6 +98,8 @@ html[data-theme="light"] {
         --tok-comment: #909090;
         --tok-builtin: #0a5a78;
         --tok-operator: #3a1888;
+        --color-bg-navbar:  #f9f9f9;
+        --color-bg-toolbar: #e6e6e6;
         --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
         --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
         --shadow-lg:        0 12px 40px rgba(0,0,0,0.20), 0 4px 14px rgba(0,0,0,0.10);
@@ -153,7 +159,7 @@ header {
     gap: 0.75rem;
     height: var(--header-height);
     padding: 0 1rem;
-    background: var(--color-bg-secondary);
+    background: var(--color-bg-navbar);
     border-bottom: 1px solid var(--color-border-primary);
     box-shadow: var(--shadow-md);
     flex-shrink: 0;
@@ -248,6 +254,7 @@ main {
     align-items: center;
     gap: 0.25rem;
     padding: 0.375rem 0.625rem;
+    background: var(--color-bg-toolbar);
     border-bottom: 1px solid var(--color-border-primary);
     flex-shrink: 0;
 }
@@ -385,7 +392,7 @@ main {
     align-items: center;
     gap: 0.25rem;
     padding: 0.375rem 0.75rem;
-    background: var(--color-bg-secondary);
+    background: var(--color-bg-toolbar);
     border-bottom: 1px solid var(--color-border-primary);
     box-shadow: 0 1px 0 var(--color-border-primary), 0 2px 6px rgba(0,0,0,0.20);
     flex-shrink: 0;
@@ -588,6 +595,14 @@ main {
     border-color: var(--color-text-primary);
     color: var(--color-bg-primary);
     box-shadow: none;
+}
+
+/* Mode toolbar buttons — normal button style when active, bottom-edge accent only */
+#mode-toolbar .btn.active {
+    background: var(--color-bg-tertiary);
+    border-color: var(--color-border-primary);
+    color: var(--color-text-primary);
+    box-shadow: var(--shadow-sm), var(--highlight-top), inset 0 -2px 0 var(--color-text-primary);
 }
 
 .btn-primary {

--- a/css/style.css
+++ b/css/style.css
@@ -13,24 +13,29 @@ html[data-theme="dark"] {
     --color-border-secondary: #202020;
     --color-text-primary: #e8e8e8;
     --color-text-secondary: #909090;
-    --color-text-tertiary: #484848;
+    --color-text-tertiary: #626262;
     --color-accent-blue: #c8c8c8;
     --color-accent-green: #a0a0a0;
     --color-accent-orange: #b0b0b0;
     --color-accent-red: #787878;
     --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
-    --panel-border-radius: 2px;
-    --header-height: 48px;
-    --sidebar-width: 240px;
-    --resize-handle-width: 5px;
-    /* Syntax token colors — matches hotnote brand theme (dark) */
-    --tok-keyword: #e8bcd4;    /* muted pink — keywords, types, class names */
-    --tok-type:    #e8bcd4;    /* muted pink */
-    --tok-string:  #b8e5f2;    /* muted cyan — strings, variables, properties */
-    --tok-number:  #c8bce8;    /* muted purple — numbers, booleans, operators */
-    --tok-comment: #888888;    /* gray — comments */
-    --tok-builtin: #b8e5f2;    /* muted cyan — builtins */
-    --tok-operator: #c8bce8;   /* muted purple */
+    --panel-border-radius: 0;
+    --header-height: 58px;
+    --sidebar-width: 288px;
+    --resize-handle-width: 6px;
+    /* Syntax token colors — vivid but not garish */
+    --tok-keyword: #d070b8;    /* magenta-rose */
+    --tok-type:    #d070b8;
+    --tok-string:  #58cce0;    /* bright cyan */
+    --tok-number:  #b098e8;    /* bright lavender */
+    --tok-comment: #666666;    /* mid gray */
+    --tok-builtin: #58cce0;
+    --tok-operator: #b098e8;
+    --shadow-sm:        0 1px 3px rgba(0,0,0,0.30), 0 1px 1px rgba(0,0,0,0.18);
+    --shadow-md:        0 2px 8px rgba(0,0,0,0.35), 0 1px 3px rgba(0,0,0,0.20);
+    --shadow-lg:        0 12px 40px rgba(0,0,0,0.55), 0 4px 14px rgba(0,0,0,0.30);
+    --highlight-top:    inset 0 1px 0 rgba(255,255,255,0.055);
+    --focus-glow:       rgba(232,232,232,0.10);
 }
 
 /* Light theme */
@@ -48,18 +53,23 @@ html[data-theme="light"] {
     --color-accent-orange: #555555;
     --color-accent-red: #222222;
     --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
-    --panel-border-radius: 2px;
-    --header-height: 48px;
-    --sidebar-width: 240px;
-    --resize-handle-width: 5px;
-    /* Syntax token colors — matches hotnote brand theme (light) */
-    --tok-keyword: #a65580;    /* darker muted pink — keywords, types, class names */
-    --tok-type:    #a65580;    /* darker muted pink */
-    --tok-string:  #5a9cb8;    /* darker muted cyan — strings, variables, properties */
-    --tok-number:  #7a65ad;    /* darker muted purple — numbers, booleans, operators */
-    --tok-comment: #999999;    /* gray — comments */
-    --tok-builtin: #5a9cb8;    /* darker muted cyan — builtins */
-    --tok-operator: #7a65ad;   /* darker muted purple */
+    --panel-border-radius: 0;
+    --header-height: 58px;
+    --sidebar-width: 288px;
+    --resize-handle-width: 6px;
+    /* Syntax token colors — clear and readable on light backgrounds */
+    --tok-keyword: #8b0a5a;    /* deep crimson-magenta */
+    --tok-type:    #8b0a5a;
+    --tok-string:  #0a5a78;    /* deep teal */
+    --tok-number:  #3a1888;    /* deep violet */
+    --tok-comment: #909090;    /* mid gray */
+    --tok-builtin: #0a5a78;
+    --tok-operator: #3a1888;
+    --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
+    --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
+    --shadow-lg:        0 12px 40px rgba(0,0,0,0.20), 0 4px 14px rgba(0,0,0,0.10);
+    --highlight-top:    inset 0 1px 0 rgba(255,255,255,0.70);
+    --focus-glow:       rgba(17,17,17,0.08);
 }
 
 /* System preference fallback (when no data-theme set yet) */
@@ -77,13 +87,18 @@ html[data-theme="light"] {
         --color-accent-green: #444444;
         --color-accent-orange: #555555;
         --color-accent-red: #222222;
-        --tok-keyword: #a65580;
-        --tok-type:    #a65580;
-        --tok-string:  #5a9cb8;
-        --tok-number:  #7a65ad;
-        --tok-comment: #999999;
-        --tok-builtin: #5a9cb8;
-        --tok-operator: #7a65ad;
+        --tok-keyword: #8b0a5a;
+        --tok-type:    #8b0a5a;
+        --tok-string:  #0a5a78;
+        --tok-number:  #3a1888;
+        --tok-comment: #909090;
+        --tok-builtin: #0a5a78;
+        --tok-operator: #3a1888;
+        --shadow-sm:        0 1px 3px rgba(0,0,0,0.10), 0 1px 1px rgba(0,0,0,0.06);
+        --shadow-md:        0 2px 8px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.07);
+        --shadow-lg:        0 12px 40px rgba(0,0,0,0.20), 0 4px 14px rgba(0,0,0,0.10);
+        --highlight-top:    inset 0 1px 0 rgba(255,255,255,0.70);
+        --focus-glow:       rgba(17,17,17,0.08);
     }
 }
 
@@ -96,6 +111,18 @@ html[data-theme="light"] {
     padding: 0;
 }
 
+html {
+    font-size: 120%; /* global 20% scale — all rem values grow with this */
+}
+
+/* Global focus ring — always visible for keyboard navigation */
+:focus-visible {
+    outline: 2px solid var(--color-text-primary);
+    outline-offset: 2px;
+}
+/* Wysiwyg handles its own focus */
+#wysiwyg:focus-visible { outline: none; }
+
 html, body {
     height: 100%;
     overflow: hidden;
@@ -103,7 +130,7 @@ html, body {
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-    font-size: 14px;
+    font-size: 0.875rem; /* 14px at default scale, 16.8px at 120% */
     line-height: 1.5;
     color: var(--color-text-primary);
     background: var(--color-bg-primary);
@@ -128,6 +155,7 @@ header {
     padding: 0 1rem;
     background: var(--color-bg-secondary);
     border-bottom: 1px solid var(--color-border-primary);
+    box-shadow: var(--shadow-md);
     flex-shrink: 0;
     z-index: 100;
 }
@@ -160,11 +188,14 @@ header {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 160px;
+    max-width: 192px;
 }
 
-#breadcrumb .crumb:hover {
+#breadcrumb .crumb:hover,
+#breadcrumb .crumb:focus-visible {
     text-decoration: underline;
+    outline: none;
+    opacity: 0.8;
 }
 
 #breadcrumb .crumb-sep {
@@ -188,14 +219,28 @@ main {
    ===================================================================== */
 #sidebar {
     width: var(--sidebar-width);
-    min-width: 120px;
-    max-width: 600px;
+    min-width: 144px;
+    max-width: 720px;
     display: flex;
     flex-direction: column;
     background: var(--color-bg-secondary);
     border-right: 1px solid var(--color-border-primary);
+    box-shadow: var(--shadow-md);
     overflow: hidden;
     flex-shrink: 0;
+    position: relative;
+    z-index: 1;
+    transition: width 0.18s ease;
+}
+
+#sidebar.collapsed {
+    width: 0 !important;
+    min-width: 0;
+    border-right: none;
+}
+
+#sidebar.collapsed + #resize-handle {
+    display: none;
 }
 
 #sidebar-toolbar {
@@ -224,7 +269,7 @@ main {
     color: var(--color-text-secondary);
     position: relative;
     user-select: none;
-    border-radius: 2px;
+    border-radius: var(--panel-border-radius);
     margin: 0 0.25rem;
 }
 
@@ -236,6 +281,7 @@ main {
 .file-entry.active {
     background: var(--color-bg-tertiary);
     color: var(--color-text-primary);
+    box-shadow: inset 2px 0 0 var(--color-text-primary);
 }
 
 .file-entry .icon {
@@ -263,20 +309,23 @@ main {
     border: none;
     color: var(--color-text-tertiary);
     cursor: pointer;
-    font-size: 0.7rem;
-    padding: 0 0.25rem;
-    line-height: 1;
+    padding: 0;
+    width: 1.5rem;
+    height: 1.5rem;
+    line-height: 0;
     flex-shrink: 0;
-    border-radius: 2px;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--panel-border-radius);
 }
 
 .file-entry:hover .delete-btn {
-    display: block;
+    display: flex;
 }
 
 .file-entry .delete-btn:hover {
-    color: var(--color-accent-red);
-    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    background: var(--color-bg-tertiary);
 }
 
 .new-file-input-wrap {
@@ -286,14 +335,21 @@ main {
 
 .new-file-input-wrap input {
     width: 100%;
-    padding: 0.25rem 0.4rem;
+    padding: 0.3rem 0.5rem;
     background: var(--color-bg-primary);
-    border: 1px solid var(--color-accent-blue);
+    border: 1px solid var(--color-text-secondary);
     color: var(--color-text-primary);
     font-size: 0.8125rem;
     font-family: var(--font-mono);
     outline: none;
     border-radius: var(--panel-border-radius);
+}
+
+.new-file-input-wrap input:focus {
+    border-color: var(--color-text-primary);
+    outline: 2px solid var(--color-text-primary);
+    outline-offset: 1px;
+    box-shadow: 0 0 0 3px var(--focus-glow);
 }
 
 /* =====================================================================
@@ -331,8 +387,11 @@ main {
     padding: 0.375rem 0.75rem;
     background: var(--color-bg-secondary);
     border-bottom: 1px solid var(--color-border-primary);
+    box-shadow: 0 1px 0 var(--color-border-primary), 0 2px 6px rgba(0,0,0,0.20);
     flex-shrink: 0;
-    min-height: 36px;
+    min-height: 44px;
+    position: relative;
+    z-index: 1;
 }
 
 #mode-toolbar .filename-display {
@@ -365,23 +424,92 @@ main {
     letter-spacing: 0.02em;
 }
 
-/* Source editor (textarea) */
-#source-editor {
+/* Source editor wrapper — takes flex-1 slot, hidden until source mode */
+#source-editor-wrap {
     flex: 1;
-    resize: none;
-    border: none;
-    outline: none;
+    position: relative;
+    overflow: hidden;
+    display: none;
     background: var(--color-bg-primary);
-    color: var(--color-text-primary);
+}
+
+/* Line number gutter */
+#line-numbers {
+    position: absolute;
+    top: 0; left: 0; bottom: 0;
+    width: 3.25rem;
+    padding: 0.75rem 0.5rem 0.75rem 0;
+    overflow: hidden;
+    pointer-events: none;
+    text-align: right;
     font-family: var(--font-mono);
     font-size: 0.8125rem;
     line-height: 1.5;
-    padding: 0.75rem;
+    color: var(--color-text-tertiary);
+    background: var(--color-bg-secondary);
+    border-right: 1px solid var(--color-border-secondary);
+    box-shadow: inset -3px 0 6px rgba(0,0,0,0.18);
+    white-space: pre;
+    user-select: none;
+    z-index: 2;
+}
+
+/* Syntax highlight backdrop — sits behind the transparent textarea */
+#source-highlight-backdrop {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    margin: 0;
+    padding: 0.75rem 0.75rem 0.75rem calc(3.25rem + 0.75rem);
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    tab-size: 4;
+    white-space: pre;
+    overflow: hidden;
+    pointer-events: none;
+    color: var(--color-text-primary);
+    word-break: normal;
+}
+
+#source-highlight-backdrop code {
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    white-space: pre;
+    tab-size: 4;
+}
+
+/* Source editor textarea — transparent overlay on top of backdrop */
+#source-editor {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    width: 100%;
+    height: 100%;
+    resize: none;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: transparent;
+    caret-color: var(--color-text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    padding: 0.75rem 0.75rem 0.75rem calc(3.25rem + 0.75rem);
     overflow: auto;
     tab-size: 4;
     white-space: pre;
-    display: none;
+    z-index: 1;
+    display: block;
 }
+
+/* Token colors for source editor backdrop */
+#source-highlight-backdrop .tok-keyword  { color: var(--tok-keyword); font-weight: 600; }
+#source-highlight-backdrop .tok-type     { color: var(--tok-type); }
+#source-highlight-backdrop .tok-string   { color: var(--tok-string); }
+#source-highlight-backdrop .tok-number   { color: var(--tok-number); }
+#source-highlight-backdrop .tok-comment  { color: var(--tok-comment); font-style: italic; }
+#source-highlight-backdrop .tok-builtin  { color: var(--tok-builtin); }
+#source-highlight-backdrop .tok-operator { color: var(--tok-operator); }
 
 /* WYSIWYG preview */
 #wysiwyg {
@@ -418,60 +546,77 @@ main {
 .btn {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.3rem;
-    padding: 0.3rem 0.6rem;
-    font-size: 0.75rem;
+    padding: 0 0.75rem;
+    height: 2rem;
+    font-size: 0.8rem;
+    font-weight: 500;
     font-family: inherit;
+    letter-spacing: 0.02em;
     border: 1px solid var(--color-border-primary);
     background: var(--color-bg-tertiary);
     color: var(--color-text-primary);
     cursor: pointer;
     border-radius: var(--panel-border-radius);
     white-space: nowrap;
-    transition: background 0.15s, border-color 0.15s;
+    transition: background 0.12s, border-color 0.12s, color 0.12s, box-shadow 0.12s;
+    user-select: none;
+    box-shadow: var(--shadow-sm), var(--highlight-top);
 }
 
 .btn:hover:not(:disabled) {
-    background: var(--color-bg-secondary);
+    background: var(--color-bg-primary);
     border-color: var(--color-text-secondary);
+    box-shadow: var(--shadow-sm);
+}
+
+.btn:active:not(:disabled) {
+    background: var(--color-bg-secondary);
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.25);
 }
 
 .btn:disabled {
-    opacity: 0.45;
+    opacity: 0.4;
     cursor: not-allowed;
 }
 
 .btn.active {
-    background: var(--color-accent-blue);
-    border-color: var(--color-accent-blue);
-    color: var(--color-bg-primary);
-}
-
-.btn-primary {
-    background: var(--color-accent-blue);
-    border-color: var(--color-accent-blue);
-    color: var(--color-bg-primary);
-}
-
-.btn-primary:hover:not(:disabled) {
     background: var(--color-text-primary);
     border-color: var(--color-text-primary);
     color: var(--color-bg-primary);
+    box-shadow: none;
 }
 
+.btn-primary {
+    background: var(--color-text-primary);
+    border-color: var(--color-text-primary);
+    color: var(--color-bg-primary);
+    box-shadow: none;
+}
+
+.btn-primary:hover:not(:disabled) {
+    background: var(--color-text-secondary);
+    border-color: var(--color-text-secondary);
+    color: var(--color-bg-primary);
+}
+
+/* Smaller variant — same height, tighter horizontal padding */
 .btn-sm {
-    padding: 0.2rem 0.5rem;
-    font-size: 0.7rem;
+    padding: 0 0.55rem;
+    font-size: 0.75rem;
 }
 
+/* Icon-only button — fixed square */
 .btn-icon {
-    padding: 0.25rem;
+    width: 2rem;
+    padding: 0;
     line-height: 0;
 }
 
 #save-btn.dirty {
-    background: var(--color-accent-blue);
-    border-color: var(--color-accent-blue);
+    background: var(--color-text-primary);
+    border-color: var(--color-text-primary);
     color: var(--color-bg-primary);
 }
 
@@ -496,7 +641,8 @@ main {
     background: var(--color-bg-secondary);
     border: 1px solid var(--color-border-primary);
     border-radius: var(--panel-border-radius);
-    max-width: 800px;
+    box-shadow: var(--shadow-lg);
+    max-width: 960px;
     width: 90vw;
     max-height: 80vh;
     display: flex;
@@ -531,21 +677,25 @@ main {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
     font-size: 0.9375rem;
     line-height: 1.75;
-    letter-spacing: 0.025em;
-    word-spacing: 0.08em;
+    letter-spacing: 0.02em;
+    word-spacing: 0.05em;
     white-space: normal;
     overflow-wrap: break-word;
-    padding: 0.75rem 1rem;
     background: var(--color-bg-primary);
     overflow: auto;
+}
+
+/* Constrain reading width and center — padding grows to center at ~72ch */
+#wysiwyg.s3-wysiwyg {
+    padding: 2rem max(2rem, calc((100% - 72ch) / 2));
 }
 
 .s3-wysiwyg:focus { outline: none; }
 
 .s3-wysiwyg h1 {
-    font-size: 2em; font-weight: 700; letter-spacing: 0.08em; word-spacing: 0.12em;
-    border-bottom: 2px solid var(--color-border-primary); padding-bottom: 0.3em;
-    margin: 1em 0 0.5em; color: var(--color-accent-blue); text-transform: uppercase;
+    font-size: 1.875em; font-weight: 700; letter-spacing: 0.01em;
+    border-bottom: 1px solid var(--color-border-primary); padding-bottom: 0.3em;
+    margin: 0.75em 0 0.5em; color: var(--color-text-primary);
 }
 .s3-wysiwyg h2 {
     font-size: 1.5em; font-weight: 600; letter-spacing: 0.06em;
@@ -557,20 +707,30 @@ main {
 .s3-wysiwyg h5 { font-size: 1em; font-weight: 600; margin: 0.6em 0 0.4em; color: var(--color-text-secondary); }
 .s3-wysiwyg h6 { font-size: 0.9em; font-weight: 600; margin: 0.6em 0 0.4em; color: var(--color-text-secondary); }
 
-.s3-wysiwyg strong { font-weight: 700; color: var(--color-accent-blue); }
+.s3-wysiwyg strong { font-weight: 700; color: var(--color-text-primary); }
 .s3-wysiwyg em { font-style: italic; color: var(--color-text-primary); }
 .s3-wysiwyg del { text-decoration: line-through; color: var(--color-text-secondary); opacity: 0.7; }
 
 .s3-wysiwyg code {
     background: var(--color-bg-tertiary); color: var(--color-accent-orange);
-    padding: 0.15rem 0.4rem; border-radius: 2px; font-family: var(--font-mono);
+    padding: 0.15rem 0.4rem; border-radius: var(--panel-border-radius); font-family: var(--font-mono);
     font-size: 0.85em; border: 1px solid var(--color-border-secondary);
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.12);
 }
 .s3-wysiwyg pre {
     background: var(--color-bg-tertiary); border: 1px solid var(--color-border-primary);
-    border-radius: 2px; padding: 1rem; margin: 1em 0; overflow-x: auto; line-height: 1.5;
+    border-radius: var(--panel-border-radius); padding: 1rem; margin: 1em 0; overflow-x: auto; line-height: 1.5;
+    box-shadow: inset 0 1px 4px rgba(0,0,0,0.18);
 }
 .s3-wysiwyg pre code { background: none; border: none; padding: 0; color: var(--color-text-primary); }
+/* Preview token colors — same hues but toned down for prose reading context */
+.s3-wysiwyg pre code .tok-keyword,
+.s3-wysiwyg pre code .tok-type,
+.s3-wysiwyg pre code .tok-string,
+.s3-wysiwyg pre code .tok-number,
+.s3-wysiwyg pre code .tok-builtin,
+.s3-wysiwyg pre code .tok-operator { opacity: 0.78; }
+.s3-wysiwyg pre code .tok-comment { opacity: 0.65; }
 
 .s3-wysiwyg ul, .s3-wysiwyg ol { padding-left: 2.5em; margin: 0.8em 0; }
 .s3-wysiwyg li { margin: 0.4em 0; line-height: 1.6; }
@@ -600,7 +760,7 @@ main {
 .s3-wysiwyg a { color: var(--color-accent-blue); text-decoration: none; border-bottom: 1px dotted var(--color-accent-blue); transition: all 0.2s ease; }
 .s3-wysiwyg a:hover { border-bottom: 1px solid var(--color-accent-blue); background: var(--color-bg-tertiary); }
 
-.s3-wysiwyg img { max-width: 100%; height: auto; margin: 1em 0; border: 1px solid var(--color-border-primary); border-radius: 2px; }
+.s3-wysiwyg img { max-width: 100%; height: auto; margin: 1em 0; border: 1px solid var(--color-border-primary); border-radius: var(--panel-border-radius); }
 
 .s3-wysiwyg table { border-collapse: collapse; width: 100%; margin: 1em 0; border: 1px solid var(--color-border-primary); }
 .s3-wysiwyg thead { background: var(--color-bg-secondary); border-bottom: 2px solid var(--color-accent-blue); }
@@ -611,7 +771,7 @@ main {
 .s3-wysiwyg hr { border: none; border-top: 2px solid var(--color-border-primary); margin: 1.5em 0; height: 1px; }
 .s3-wysiwyg p { margin: 0.8em 0; line-height: 1.75; }
 .s3-wysiwyg p img {
-    max-height: 20px;
+    max-height: 24px;
     width: auto;
     max-width: 100%;
     vertical-align: middle;
@@ -627,7 +787,7 @@ main {
     font-family: var(--font-mono);
     padding: 0.1rem 0.3rem;
     border: 1px dashed var(--color-border-primary);
-    border-radius: 2px;
+    border-radius: var(--panel-border-radius);
 }
 
 /* =====================================================================
@@ -731,7 +891,7 @@ main {
 .s3-nested-json {
     background: var(--color-bg-tertiary);
     padding: 1rem;
-    border-radius: 2px;
+    border-radius: var(--panel-border-radius);
     border: 1px solid var(--color-border-primary);
     overflow-x: auto;
     max-height: 400px;
@@ -851,7 +1011,7 @@ main {
 .autosave-toggle {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 5px;
     font-size: 0.8rem;
     color: var(--color-text-secondary);
     cursor: pointer;

--- a/css/style.css
+++ b/css/style.css
@@ -464,18 +464,19 @@ main {
     font-size: 0.8125rem;
     line-height: 1.5;
     tab-size: 4;
-    white-space: pre;
+    white-space: pre-wrap;
+    word-break: break-word;
     overflow: hidden;
     pointer-events: none;
     color: var(--color-text-primary);
-    word-break: normal;
 }
 
 #source-highlight-backdrop code {
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
-    white-space: pre;
+    white-space: pre-wrap;
+    word-break: break-word;
     tab-size: 4;
 }
 
@@ -497,7 +498,8 @@ main {
     padding: 0.75rem 0.75rem 0.75rem calc(3.25rem + 0.75rem);
     overflow: auto;
     tab-size: 4;
-    white-space: pre;
+    white-space: pre-wrap;
+    word-break: break-word;
     z-index: 1;
     display: block;
 }

--- a/index.html
+++ b/index.html
@@ -21,12 +21,12 @@
         <button class="btn" id="open-folder">Open Folder</button>
         <div id="breadcrumb"></div>
         <div class="spacer"></div>
-        <button class="btn btn-sm" id="theme-toggle" title="Toggle theme" aria-label="Toggle dark/light theme">◑</button>
         <label class="autosave-toggle" id="autosave-toggle-label">
             <input type="checkbox" id="autosave-checkbox" />
             <span id="autosave-label">autosave</span>
         </label>
         <button class="btn btn-primary" id="save-btn" disabled>Save</button>
+        <button class="btn btn-sm" id="theme-toggle" title="Toggle theme" aria-label="Toggle dark/light theme">◑</button>
     </header>
     <main>
         <aside id="sidebar">

--- a/index.html
+++ b/index.html
@@ -18,19 +18,27 @@
 <div id="app">
     <header>
         <span class="logo">HotNote</span>
-        <button class="btn" id="open-folder">Open Folder</button>
+        <button class="btn btn-sm btn-icon" id="sidebar-toggle" title="Toggle sidebar" aria-label="Toggle sidebar">
+            <svg id="sidebar-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+        </button>
+        <button class="btn" id="open-folder" title="Open a local folder">Open Folder</button>
         <div id="breadcrumb"></div>
         <div class="spacer"></div>
-        <label class="autosave-toggle" id="autosave-toggle-label">
-            <input type="checkbox" id="autosave-checkbox" />
+        <label class="autosave-toggle" id="autosave-toggle-label" title="Automatically save changes after 2 seconds of inactivity">
+            <input type="checkbox" id="autosave-checkbox" aria-label="Autosave" />
             <span id="autosave-label">autosave</span>
         </label>
-        <button class="btn btn-primary" id="save-btn" disabled>Save</button>
-        <button class="btn btn-sm" id="theme-toggle" title="Toggle theme" aria-label="Toggle dark/light theme">◑</button>
+        <button class="btn btn-primary" id="save-btn" disabled title="Save file (Ctrl+S / Cmd+S)" aria-label="Save file">Save</button>
+        <button class="btn btn-sm btn-icon" id="theme-toggle" title="Toggle light/dark theme" aria-label="Toggle light/dark theme">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        </button>
     </header>
     <main>
         <aside id="sidebar">
             <div id="sidebar-toolbar">
+                <button class="btn btn-sm btn-icon" id="up-btn" title="Go up" aria-label="Go up" disabled>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="18 15 12 9 6 15"/></svg>
+                </button>
                 <button class="btn btn-sm btn-icon" id="new-file-btn" title="New file" aria-label="New file">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/><line x1="12" y1="13" x2="12" y2="19"/><line x1="9" y1="16" x2="15" y2="16"/></svg>
                 </button>
@@ -43,10 +51,15 @@
         <div id="resize-handle"></div>
         <section id="editor-area">
             <div id="mode-toolbar" style="display:none"></div>
-            <textarea id="source-editor" spellcheck="false"></textarea>
+            <div id="source-editor-wrap">
+                <div id="line-numbers" aria-hidden="true"></div>
+                <pre id="source-highlight-backdrop" aria-hidden="true"><code id="source-highlight-code"></code></pre>
+                <textarea id="source-editor" spellcheck="false"></textarea>
+            </div>
             <div id="wysiwyg" contenteditable="false"></div>
             <div id="s3-datasheet" style="display:none"></div>
             <div id="s3-treeview" style="display:none"></div>
+            <div id="image-viewer" style="display:none"></div>
         </section>
     </main>
 </div>
@@ -56,7 +69,9 @@
     <div class="modal-box">
         <div class="modal-header">
             <span class="modal-title" id="nested-title">Nested Data</span>
-            <button class="btn btn-sm" id="nested-modal-close">✕</button>
+            <button class="btn btn-sm btn-icon" id="nested-modal-close" title="Close" aria-label="Close">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            </button>
         </div>
         <div class="modal-body" id="nested-body"></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
         <div id="breadcrumb"></div>
         <div class="spacer"></div>
         <button class="btn btn-sm" id="theme-toggle" title="Toggle theme" aria-label="Toggle dark/light theme">◑</button>
+        <label class="autosave-toggle" id="autosave-toggle-label">
+            <input type="checkbox" id="autosave-checkbox" />
+            <span id="autosave-label">autosave</span>
+        </label>
         <button class="btn btn-primary" id="save-btn" disabled>Save</button>
     </header>
     <main>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <input type="checkbox" id="autosave-checkbox" aria-label="Autosave" />
             <span id="autosave-label">autosave</span>
         </label>
-        <button class="btn btn-primary" id="save-btn" disabled title="Save file (Ctrl+S / Cmd+S)" aria-label="Save file">Save</button>
+        <button class="btn" id="save-btn" disabled title="Save file (Ctrl+S / Cmd+S)" aria-label="Save file">Save</button>
         <button class="btn btn-sm btn-icon" id="theme-toggle" title="Toggle light/dark theme" aria-label="Toggle light/dark theme">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
         </button>

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -127,7 +127,9 @@ async function openFolder() {
         state.currentFileHandle = null;
         state.currentFilename = '';
         clearEditor();
-        document.getElementById('sidebar').style.display = '';
+        const sidebarEl = document.getElementById('sidebar');
+        sidebarEl.style.display = '';
+        sidebarEl.classList.remove('collapsed');
         document.getElementById('resize-handle').style.display = '';
         await renderSidebar();
         renderBreadcrumb();
@@ -147,22 +149,39 @@ function renderBreadcrumb() {
     if (!el) return;
     if (!state.pathStack.length) {
         el.innerHTML = '';
+        updateUpButton();
         return;
     }
     el.innerHTML = state.pathStack.map((crumb, i) => {
         const isLast = i === state.pathStack.length - 1;
-        return `<span class="crumb${isLast ? ' crumb-current' : ''}" data-idx="${i}">${escapeHtml(crumb.name)}</span>` +
+        return `<span class="crumb${isLast ? ' crumb-current' : ''}" data-idx="${i}" title="${escapeHtml(crumb.name)}"${!isLast ? ' role="button" tabindex="0"' : ''}>${escapeHtml(crumb.name)}</span>` +
                (isLast ? '' : '<span class="crumb-sep">/</span>');
     }).join('');
     el.querySelectorAll('.crumb:not(.crumb-current)').forEach(el => {
-        el.addEventListener('click', async () => {
+        const navigate = async () => {
             const idx = parseInt(el.dataset.idx, 10);
             state.pathStack = state.pathStack.slice(0, idx + 1);
             state.currentDirHandle = state.pathStack[state.pathStack.length - 1].handle;
             await renderSidebar();
             renderBreadcrumb();
-        });
+        };
+        el.addEventListener('click', navigate);
+        el.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate(); } });
     });
+    updateUpButton();
+}
+
+function updateUpButton() {
+    const btn = document.getElementById('up-btn');
+    if (btn) btn.disabled = state.pathStack.length <= 1;
+}
+
+async function navigateUp() {
+    if (state.pathStack.length <= 1) return;
+    state.pathStack.pop();
+    state.currentDirHandle = state.pathStack[state.pathStack.length - 1].handle;
+    await renderSidebar();
+    renderBreadcrumb();
 }
 
 // =========================================================================
@@ -205,7 +224,7 @@ function renderFileEntry(entry) {
     li.innerHTML = `
         <span class="icon">${icon}</span>
         <span class="name" title="${escapeHtml(entry.name)}">${escapeHtml(entry.name)}</span>
-        <button class="delete-btn" title="Delete">✕</button>
+        <button class="delete-btn" title="Delete ${escapeHtml(entry.name)}" aria-label="Delete ${escapeHtml(entry.name)}"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
     `;
 
     // Click handler
@@ -361,36 +380,16 @@ async function openFile(fileHandle, filename) {
 }
 
 function determineInitialMode(ext, content) {
-    // JSON handling
+    // JSON: treeview if valid, else source
     if (ext === 'json') {
-        const ds = detectDatasheetMode(content);
-        if (ds.isDatasheet) {
-            state.editorMode = 'datasheet';
-            state.datasheetData = ds.data;
-            state.datasheetSchema = inferSchema(ds.data);
-            state.datasheetPage = 1;
+        const jt = detectJsonType(content);
+        if (jt.isObject || jt.isArray) {
+            state.editorMode = 'treeview';
+            state.treeviewData = jt.parsed;
+            state.treeviewCollapsed = new Set();
         } else {
-            const jt = detectJsonType(content);
-            if (jt.isObject || jt.isArray) {
-                state.editorMode = 'treeview';
-                state.treeviewData = jt.parsed;
-                state.treeviewCollapsed = new Set();
-            } else {
-                state.editorMode = 'source';
-            }
+            state.editorMode = 'source';
         }
-        return;
-    }
-
-    // Markdown handling
-    if (shouldUseWysiwygMode(ext, content)) {
-        state.editorMode = 'wysiwyg';
-        return;
-    }
-
-    // Code file handling — default to highlighted view
-    if (CODE_EXTENSIONS.has(ext)) {
-        state.editorMode = 'highlight';
         return;
     }
 
@@ -423,25 +422,20 @@ function updateModeToolbar() {
     const ext = getExtension(state.currentFilename);
     const isJson = ext === 'json';
     const isMd = ext === 'md';
-    const isCode = CODE_EXTENSIONS.has(ext);
 
-    const ds = isJson ? detectDatasheetMode(document.getElementById('source-editor').value) : { isDatasheet: false };
     const jt = isJson ? detectJsonType(document.getElementById('source-editor').value) : { isObject: false, isArray: false };
+    const hasTree = isJson && (jt.isObject || jt.isArray);
 
     const modeToolbar = document.getElementById('mode-toolbar');
     modeToolbar.innerHTML = `
         <button class="btn btn-sm${state.editorMode === 'source' ? ' active' : ''}" id="mode-source">Source</button>
         ${isMd ? `<button class="btn btn-sm${state.editorMode === 'wysiwyg' ? ' active' : ''}" id="mode-wysiwyg">Preview</button>` : ''}
-        ${(isCode || isJson) ? `<button class="btn btn-sm${state.editorMode === 'highlight' ? ' active' : ''}" id="mode-highlight">View</button>` : ''}
-        ${(isJson && ds.isDatasheet) ? `<button class="btn btn-sm${state.editorMode === 'datasheet' ? ' active' : ''}" id="mode-datasheet">Datasheet</button>` : ''}
-        ${(isJson && (jt.isObject || jt.isArray)) ? `<button class="btn btn-sm${state.editorMode === 'treeview' ? ' active' : ''}" id="mode-treeview">Tree</button>` : ''}
+        ${hasTree ? `<button class="btn btn-sm${state.editorMode === 'treeview' ? ' active' : ''}" id="mode-treeview">Tree</button>` : ''}
         <span id="filename-display" class="filename-display">${escapeHtml(state.currentFilename)}</span>
     `;
 
     document.getElementById('mode-source')?.addEventListener('click', () => switchToMode('source'));
     document.getElementById('mode-wysiwyg')?.addEventListener('click', () => switchToMode('wysiwyg'));
-    document.getElementById('mode-highlight')?.addEventListener('click', () => switchToMode('highlight'));
-    document.getElementById('mode-datasheet')?.addEventListener('click', () => switchToMode('datasheet'));
     document.getElementById('mode-treeview')?.addEventListener('click', () => switchToMode('treeview'));
 }
 
@@ -575,6 +569,30 @@ function getHighlightRules(lang) {
                 { regex: /\b(true|false|null|yes|no|on|off)\b/y, type: 'keyword' },
                 num, op,
             ];
+        case 'md': case 'markdown':
+            return [
+                // Fenced code blocks
+                { regex: /```[\s\S]*?```/y, type: 'comment' },
+                // Inline code
+                str(/`[^`\n]+`/y),
+                // Headers
+                { regex: /^#{1,6} [^\n]*/my, type: 'keyword' },
+                // Blockquotes
+                { regex: /^> [^\n]*/my, type: 'comment' },
+                // Bold
+                { regex: /\*\*[^*\n]+\*\*/y, type: 'type' },
+                { regex: /__[^_\n]+__/y, type: 'type' },
+                // Italic
+                { regex: /\*[^*\n]+\*/y, type: 'string' },
+                { regex: /_[^_\n]+_/y, type: 'string' },
+                // Links and images
+                { regex: /!?\[[^\]\n]*\]\([^)\n]*\)/y, type: 'builtin' },
+                // List markers
+                { regex: /^[-*+] /my, type: 'operator' },
+                { regex: /^\d+\. /my, type: 'number' },
+                // Horizontal rules
+                { regex: /^[-*]{3,}$/my, type: 'operator' },
+            ];
         default:
             return [
                 comment(/\/\/[^\n]*/y),
@@ -680,16 +698,35 @@ function animateAutosaveLabel() {
     }, 1500);
 }
 
+function updateSourceHighlight() {
+    const codeEl = document.getElementById('source-highlight-code');
+    if (!codeEl) return;
+    const textarea = document.getElementById('source-editor');
+    const content = textarea.value;
+    const lang = getExtension(state.currentFilename);
+
+    // Trailing newline prevents last-line clipping
+    codeEl.innerHTML = highlightCode(content + '\n', lang);
+
+    // Update line numbers
+    const lineNumEl = document.getElementById('line-numbers');
+    if (lineNumEl) {
+        const lineCount = (content.match(/\n/g) || []).length + 1;
+        lineNumEl.textContent = Array.from({ length: lineCount }, (_, i) => i + 1).join('\n');
+    }
+}
+
 function switchToMode(mode, content) {
     state.editorMode = mode;
 
+    const wrap = document.getElementById('source-editor-wrap');
     const textarea = document.getElementById('source-editor');
     const wysiwyg = document.getElementById('wysiwyg');
     const datasheet = document.getElementById('s3-datasheet');
     const treeview = document.getElementById('s3-treeview');
 
     // Hide all panels
-    textarea.style.display = 'none';
+    wrap.style.display = 'none';
     wysiwyg.style.display = 'none';
     datasheet.style.display = 'none';
     treeview.style.display = 'none';
@@ -698,7 +735,8 @@ function switchToMode(mode, content) {
 
     switch (mode) {
         case 'source':
-            textarea.style.display = 'block';
+            wrap.style.display = 'block';
+            updateSourceHighlight();
             textarea.focus();
             break;
 
@@ -715,16 +753,6 @@ function switchToMode(mode, content) {
             applySyntaxHighlighting(wysiwyg);
             break;
 
-        case 'datasheet': {
-            const parsed = JSON.parse(currentContent);
-            state.datasheetData = parsed;
-            state.datasheetSchema = inferSchema(parsed);
-            state.datasheetPage = 1;
-            datasheet.style.display = 'flex';
-            renderDatasheet();
-            break;
-        }
-
         case 'treeview': {
             const jt = detectJsonType(currentContent);
             state.treeviewData = jt.parsed;
@@ -734,14 +762,6 @@ function switchToMode(mode, content) {
             break;
         }
 
-        case 'highlight': {
-            const lang = getExtension(state.currentFilename);
-            wysiwyg.style.display = 'block';
-            wysiwyg.className = 'code-highlight-view';
-            wysiwyg.contentEditable = 'false';
-            wysiwyg.innerHTML = `<pre class="code-highlight-pre"><code>${highlightCode(currentContent, lang)}</code></pre>`;
-            break;
-        }
     }
 
     // Update toolbar buttons
@@ -758,13 +778,14 @@ function clearEditor() {
     state.editorMode = 'source';
     updateTitle();
 
+    const wrap = document.getElementById('source-editor-wrap');
     const textarea = document.getElementById('source-editor');
     const wysiwyg = document.getElementById('wysiwyg');
     const datasheet = document.getElementById('s3-datasheet');
     const treeview = document.getElementById('s3-treeview');
     const toolbar = document.getElementById('mode-toolbar');
 
-    textarea.style.display = 'none';
+    wrap.style.display = 'none';
     textarea.value = '';
     wysiwyg.style.display = 'none';
     datasheet.style.display = 'none';
@@ -827,6 +848,11 @@ function updateTitle() {
 // Sidebar Resize
 // =========================================================================
 
+function toggleSidebar() {
+    const sidebar = document.getElementById('sidebar');
+    if (sidebar) sidebar.classList.toggle('collapsed');
+}
+
 function initResizeHandle() {
     const handle = document.getElementById('resize-handle');
     const sidebar = document.getElementById('sidebar');
@@ -845,7 +871,7 @@ function initResizeHandle() {
 
     document.addEventListener('mousemove', (e) => {
         if (!handle.classList.contains('dragging')) return;
-        const newWidth = Math.max(120, Math.min(600, startWidth + (e.clientX - startX)));
+        const newWidth = Math.max(144, Math.min(720, startWidth + (e.clientX - startX)));
         sidebar.style.width = `${newWidth}px`;
     });
 
@@ -1086,22 +1112,6 @@ function renderTreeView() {
         });
     });
 
-    // Attach datasheet link handlers
-    container.querySelectorAll('.tree-datasheet-link').forEach(el => {
-        el.addEventListener('click', (e) => {
-            e.preventDefault();
-            // Navigate data path to get the array
-            const path = el.dataset.treePath;
-            const arr = getValueAtPath(state.treeviewData, path);
-            if (arr) {
-                state.datasheetData = arr;
-                state.datasheetSchema = inferSchema(arr);
-                state.datasheetPage = 1;
-                switchToMode('datasheet');
-                updateModeToolbar();
-            }
-        });
-    });
 }
 
 function getValueAtPath(root, path) {
@@ -1144,17 +1154,12 @@ function renderTreeNode(value, path, key) {
 
     if (Array.isArray(value)) {
         const toggleIcon = isCollapsed ? '▶' : '▼';
-        const canShowDatasheet = value.length > 0 &&
-            value.every((item) => typeof item === 'object' && item !== null && !Array.isArray(item));
 
         let html = `<div class="tree-item tree-expandable">
             <span class="tree-toggle" data-tree-path="${escapeHtml(fullPath)}">${toggleIcon}</span>
             <span class="tree-key">${escapeHtml(String(key))}:</span>
             <span class="tree-bracket">[</span><span class="tree-count">${value.length} items</span><span class="tree-bracket">]</span>`;
 
-        if (canShowDatasheet) {
-            html += ` <a href="#" class="tree-datasheet-link" data-tree-path="${escapeHtml(fullPath)}">(datasheet)</a>`;
-        }
         html += '</div>';
 
         if (!isCollapsed) {
@@ -1285,11 +1290,29 @@ document.addEventListener('DOMContentLoaded', () => {
     saveBtn?.addEventListener('click', saveFile);
 
     // Sidebar toolbar buttons
+    document.getElementById('up-btn')?.addEventListener('click', navigateUp);
     document.getElementById('new-file-btn')?.addEventListener('click', showNewFileInput);
     document.getElementById('new-folder-btn')?.addEventListener('click', showNewFolderInput);
 
-    // Textarea dirty tracking
-    document.getElementById('source-editor')?.addEventListener('input', setDirty);
+    // Textarea dirty tracking + highlight sync
+    const sourceEditor = document.getElementById('source-editor');
+    sourceEditor?.addEventListener('input', () => {
+        setDirty();
+        updateSourceHighlight();
+    });
+
+    // Scroll sync: keep highlight backdrop and line numbers aligned with textarea
+    sourceEditor?.addEventListener('scroll', () => {
+        const backdrop = document.getElementById('source-highlight-backdrop');
+        const lineNums = document.getElementById('line-numbers');
+        if (backdrop) {
+            backdrop.scrollTop = sourceEditor.scrollTop;
+            backdrop.scrollLeft = sourceEditor.scrollLeft;
+        }
+        if (lineNums) {
+            lineNums.scrollTop = sourceEditor.scrollTop;
+        }
+    });
 
     // Ctrl+S / Cmd+S save
     document.addEventListener('keydown', (e) => {
@@ -1301,6 +1324,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Resize handle
     initResizeHandle();
+
+    // Sidebar toggle
+    document.getElementById('sidebar-toggle')?.addEventListener('click', toggleSidebar);
+
+    // Auto-collapse sidebar on narrow viewports
+    const autoCollapseMQ = window.matchMedia('(max-width: 720px)');
+    function handleAutoCollapse(mq) {
+        const sidebar = document.getElementById('sidebar');
+        if (!sidebar) return;
+        if (mq.matches) {
+            sidebar.classList.add('collapsed');
+        }
+    }
+    autoCollapseMQ.addEventListener('change', handleAutoCollapse);
+    handleAutoCollapse(autoCollapseMQ);
 
     // Nested modal close
     document.getElementById('nested-modal-close')?.addEventListener('click', closeNestedModal);

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -616,10 +616,14 @@ function highlightCode(text, lang) {
 
 function applySyntaxHighlighting(container) {
     container.querySelectorAll('pre > code').forEach(code => {
-        const pre = code.parentElement;
-        const lang = getCodeLang(pre);
-        const text = code.textContent;
-        code.innerHTML = highlightCode(text, lang);
+        try {
+            const pre = code.parentElement;
+            const lang = getCodeLang(pre);
+            const text = code.textContent;
+            code.innerHTML = highlightCode(text, lang);
+        } catch (e) {
+            console.error('Syntax highlight error:', e);
+        }
     });
 }
 

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -34,6 +34,9 @@ const state = {
     treeviewCollapsed: new Set(),
     // Navigation: [{handle, name}]
     pathStack: [],
+    // Autosave
+    autosaveEnabled: false,
+    autosaveTimer: null,
 };
 
 // =========================================================================
@@ -340,6 +343,15 @@ async function openFile(fileHandle, filename) {
     const ext = getExtension(filename);
     determineInitialMode(ext, content);
     renderEditor(content, filename);
+
+    // Enable autosave controls
+    const autosaveCheckbox = document.getElementById('autosave-checkbox');
+    const autosaveToggleLabel = document.getElementById('autosave-toggle-label');
+    if (autosaveCheckbox) {
+        autosaveCheckbox.disabled = false;
+        autosaveCheckbox.checked = state.autosaveEnabled;
+    }
+    if (autosaveToggleLabel) autosaveToggleLabel.style.opacity = '';
 }
 
 function determineInitialMode(ext, content) {
@@ -448,6 +460,206 @@ async function resolveLocalImages(container) {
     }
 }
 
+// =========================================================================
+// Syntax Highlighting
+// =========================================================================
+
+function getCodeLang(pre) {
+    const md = pre.getAttribute('data-md') || '';
+    const match = md.match(/^```(\w+)/);
+    return match ? match[1].toLowerCase() : '';
+}
+
+function getHighlightRules(lang) {
+    const comment = (pattern) => ({ regex: pattern, type: 'comment' });
+    const str = (pattern) => ({ regex: pattern, type: 'string' });
+    const num = { regex: /\b\d+(\.\d+)?([eE][+-]?\d+)?\b/y, type: 'number' };
+    const op = { regex: /[+\-*/%&|^~<>!=?:;,.()[\]{}]+/y, type: 'operator' };
+
+    switch (lang) {
+        case 'js': case 'javascript': case 'ts': case 'typescript': case 'jsx': case 'tsx':
+            return [
+                comment(/\/\/[^\n]*/y),
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/`(?:[^`\\]|\\.)*`/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /\b(break|case|catch|class|const|continue|debugger|default|delete|do|else|export|extends|finally|for|function|if|import|in|instanceof|let|new|of|return|static|super|switch|this|throw|try|typeof|var|void|while|with|yield|async|await)\b/y, type: 'keyword' },
+                { regex: /\b(Array|Boolean|Date|Error|Function|Map|Number|Object|Promise|RegExp|Set|String|Symbol|WeakMap|WeakSet|JSON|Math|console|document|window|undefined|null|true|false|NaN|Infinity)\b/y, type: 'type' },
+                num, op,
+            ];
+        case 'go':
+            return [
+                comment(/\/\/[^\n]*/y),
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/`(?:[^`])*`/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /\b(break|case|chan|const|continue|default|defer|else|fallthrough|for|func|go|goto|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b/y, type: 'keyword' },
+                { regex: /\b(bool|byte|complex64|complex128|error|float32|float64|int|int8|int16|int32|int64|rune|string|uint|uint8|uint16|uint32|uint64|uintptr|true|false|nil|iota|append|cap|close|copy|delete|len|make|new|panic|print|println|recover)\b/y, type: 'type' },
+                num, op,
+            ];
+        case 'py': case 'python':
+            return [
+                comment(/#[^\n]*/y),
+                str(/"""[\s\S]*?"""/y),
+                str(/'''[\s\S]*?'''/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /\b(and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\b/y, type: 'keyword' },
+                { regex: /\b(True|False|None|int|float|str|list|dict|set|tuple|bool|type|object|super|print|len|range|enumerate|zip|map|filter|sorted|reversed|open|input)\b/y, type: 'builtin' },
+                num, op,
+            ];
+        case 'rs': case 'rust':
+            return [
+                comment(/\/\/[^\n]*/y),
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                { regex: /\b(as|async|await|break|const|continue|crate|dyn|else|enum|extern|false|fn|for|if|impl|in|let|loop|match|mod|move|mut|pub|ref|return|self|Self|static|struct|super|trait|true|type|unsafe|use|where|while)\b/y, type: 'keyword' },
+                { regex: /\b(bool|char|f32|f64|i8|i16|i32|i64|i128|isize|str|u8|u16|u32|u64|u128|usize|String|Vec|Option|Result|Box|Rc|Arc|HashMap|HashSet)\b/y, type: 'type' },
+                num, op,
+            ];
+        case 'sh': case 'bash': case 'shell': case 'zsh':
+            return [
+                comment(/#[^\n]*/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'[^']*'/y),
+                { regex: /\b(if|then|else|elif|fi|for|while|do|done|case|esac|in|function|return|exit|echo|export|source|local|readonly|shift|unset|set|trap)\b/y, type: 'keyword' },
+                num, op,
+            ];
+        case 'json':
+            return [
+                str(/"(?:[^"\\]|\\.)*"/y),
+                { regex: /\b(true|false|null)\b/y, type: 'keyword' },
+                num, op,
+            ];
+        case 'css':
+            return [
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /\b(important|auto|none|inherit|initial|unset|normal|bold|italic|solid|dashed|dotted|left|right|center|top|bottom|flex|grid|block|inline|absolute|relative|fixed|sticky|hidden|visible)\b/y, type: 'keyword' },
+                { regex: /\b\d+(\.\d+)?(px|em|rem|vh|vw|%|pt|cm|mm|s|ms)?\b/y, type: 'number' },
+                { regex: /#[0-9a-fA-F]{3,6}\b/y, type: 'string' },
+                op,
+            ];
+        case 'html': case 'xml':
+            return [
+                comment(/<!--[\s\S]*?-->/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                { regex: /<\/?[a-zA-Z][a-zA-Z0-9-]*/y, type: 'keyword' },
+                op,
+            ];
+        case 'yaml': case 'yml':
+            return [
+                comment(/#[^\n]*/y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'[^']*'/y),
+                { regex: /\b(true|false|null|yes|no|on|off)\b/y, type: 'keyword' },
+                num, op,
+            ];
+        default:
+            return [
+                comment(/\/\/[^\n]*/y),
+                comment(/#[^\n]*/y),
+                comment(/\/\*[\s\S]*?\*\//y),
+                str(/"(?:[^"\\]|\\.)*"/y),
+                str(/'(?:[^'\\]|\\.)*'/y),
+                num, op,
+            ];
+    }
+}
+
+function tokenize(code, rules) {
+    const tokens = [];
+    let i = 0;
+    const len = code.length;
+
+    while (i < len) {
+        let matched = false;
+        for (const rule of rules) {
+            rule.regex.lastIndex = i;
+            const m = rule.regex.exec(code);
+            if (m && m.index === i) {
+                tokens.push({ type: rule.type, value: m[0] });
+                i += m[0].length;
+                matched = true;
+                break;
+            }
+        }
+        if (!matched) {
+            const last = tokens[tokens.length - 1];
+            if (last && last.type === 'plain') {
+                last.value += code[i];
+            } else {
+                tokens.push({ type: 'plain', value: code[i] });
+            }
+            i++;
+        }
+    }
+    return tokens;
+}
+
+function highlightCode(text, lang) {
+    const rules = getHighlightRules(lang);
+    const tokens = tokenize(text, rules);
+    return tokens.map(t => {
+        const escaped = t.value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        if (t.type === 'plain') return escaped;
+        return `<span class="tok-${t.type}">${escaped}</span>`;
+    }).join('');
+}
+
+function applySyntaxHighlighting(container) {
+    container.querySelectorAll('pre > code').forEach(code => {
+        const pre = code.parentElement;
+        const lang = getCodeLang(pre);
+        const text = code.textContent;
+        code.innerHTML = highlightCode(text, lang);
+    });
+}
+
+// =========================================================================
+// Autosave
+// =========================================================================
+
+function loadAutosavePref() {
+    const saved = localStorage.getItem('hotnote2-autosave');
+    return saved !== null ? saved === 'true' : true; // default enabled
+}
+
+function saveAutosavePref(enabled) {
+    localStorage.setItem('hotnote2-autosave', String(enabled));
+}
+
+function startAutosaveTimer() {
+    if (state.autosaveTimer) clearTimeout(state.autosaveTimer);
+    state.autosaveTimer = setTimeout(() => {
+        state.autosaveTimer = null;
+        if (state.isDirty && state.currentFileHandle && state.autosaveEnabled) {
+            saveFile(true);
+        }
+    }, 2000);
+}
+
+function animateAutosaveLabel() {
+    const label = document.getElementById('autosave-label');
+    if (!label) return;
+    label.textContent = 'saved';
+    label.classList.remove('fade-out', 'hidden');
+    setTimeout(() => {
+        label.classList.add('fade-out');
+        setTimeout(() => {
+            label.textContent = 'autosave';
+            label.classList.remove('fade-out');
+        }, 500);
+    }, 1500);
+}
+
 function switchToMode(mode, content) {
     state.editorMode = mode;
 
@@ -480,6 +692,7 @@ function switchToMode(mode, content) {
                 wysiwyg.textContent = currentContent;
             }
             resolveLocalImages(wysiwyg).catch(console.error);
+            applySyntaxHighlighting(wysiwyg);
             break;
 
         case 'datasheet': {
@@ -537,13 +750,19 @@ function clearEditor() {
         emptyState.innerHTML = '<h2>No file open</h2><p>Use <b>Open Folder</b> to browse local files.</p>';
         editorArea.appendChild(emptyState);
     }
+
+    // Disable autosave controls when no file is open
+    const autosaveCheckbox = document.getElementById('autosave-checkbox');
+    const autosaveToggleLabel = document.getElementById('autosave-toggle-label');
+    if (autosaveCheckbox) autosaveCheckbox.disabled = true;
+    if (autosaveToggleLabel) autosaveToggleLabel.style.opacity = '0.4';
 }
 
 // =========================================================================
 // Save
 // =========================================================================
 
-async function saveFile() {
+async function saveFile(silent = false) {
     if (!state.currentFileHandle) return;
     const textarea = document.getElementById('source-editor');
     try {
@@ -552,8 +771,10 @@ async function saveFile() {
         updateTitle();
         const saveBtn = document.getElementById('save-btn');
         if (saveBtn) { saveBtn.classList.remove('dirty'); saveBtn.disabled = true; }
+        if (silent) animateAutosaveLabel();
     } catch (err) {
-        alert(`Failed to save: ${err.message}`);
+        if (!silent) alert(`Failed to save: ${err.message}`);
+        else console.error('Autosave failed:', err);
     }
 }
 
@@ -564,6 +785,7 @@ function setDirty() {
         const saveBtn = document.getElementById('save-btn');
         if (saveBtn) { saveBtn.classList.add('dirty'); saveBtn.disabled = false; }
     }
+    startAutosaveTimer();
 }
 
 function updateTitle() {
@@ -1062,6 +1284,20 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('resize-handle').style.display = 'none';
     clearEditor();
     updateTitle();
+
+    // Autosave init
+    state.autosaveEnabled = loadAutosavePref();
+    const autosaveCheckbox = document.getElementById('autosave-checkbox');
+    const autosaveToggleLabel = document.getElementById('autosave-toggle-label');
+    if (autosaveCheckbox) {
+        autosaveCheckbox.addEventListener('change', (e) => {
+            state.autosaveEnabled = e.target.checked;
+            saveAutosavePref(e.target.checked);
+        });
+    }
+    // Initially disabled until a file is open (clearEditor will set these too, but explicit here)
+    if (autosaveToggleLabel) autosaveToggleLabel.style.opacity = '0.4';
+    if (autosaveCheckbox) autosaveCheckbox.disabled = true;
 
     // Check if File System Access API is available
     if (!window.showDirectoryPicker) {

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -1348,6 +1348,17 @@ document.addEventListener('DOMContentLoaded', () => {
     // Open folder button
     document.getElementById('open-folder')?.addEventListener('click', openFolder);
 
+    // Wysiwyg link clicks — open in new tab so we don't navigate away
+    document.getElementById('wysiwyg')?.addEventListener('click', (e) => {
+        const link = e.target.closest('a[href]');
+        if (!link) return;
+        e.preventDefault();
+        const href = link.getAttribute('href');
+        if (href && href !== '#') {
+            window.open(href, '_blank', 'noopener,noreferrer');
+        }
+    });
+
     // Save button
     const saveBtn = document.getElementById('save-btn');
     saveBtn?.addEventListener('click', saveFile);

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -14,6 +14,12 @@ const TEXT_EXTENSIONS = new Set([
     'graphql', 'proto', 'tf', 'hcl', 'log', 'csv',
 ]);
 
+const CODE_EXTENSIONS = new Set([
+    'js', 'ts', 'jsx', 'tsx', 'go', 'py', 'rb', 'rs', 'css', 'scss',
+    'html', 'htm', 'xml', 'sh', 'bash', 'zsh', 'yaml', 'yml',
+    'toml', 'sql', 'graphql', 'proto', 'tf', 'hcl', 'conf', 'ini', 'cfg',
+]);
+
 // =========================================================================
 // State
 // =========================================================================
@@ -24,7 +30,7 @@ const state = {
     currentFileHandle: null,
     currentFilename: '',
     isDirty: false,
-    editorMode: 'source', // 'source' | 'wysiwyg' | 'datasheet' | 'treeview'
+    editorMode: 'source', // 'source' | 'wysiwyg' | 'highlight' | 'datasheet' | 'treeview'
     // JSON view state
     datasheetData: null,
     datasheetSchema: null,
@@ -379,9 +385,16 @@ function determineInitialMode(ext, content) {
     // Markdown handling
     if (shouldUseWysiwygMode(ext, content)) {
         state.editorMode = 'wysiwyg';
-    } else {
-        state.editorMode = 'source';
+        return;
     }
+
+    // Code file handling — default to highlighted view
+    if (CODE_EXTENSIONS.has(ext)) {
+        state.editorMode = 'highlight';
+        return;
+    }
+
+    state.editorMode = 'source';
 }
 
 function renderEditor(content, filename) {
@@ -410,6 +423,7 @@ function updateModeToolbar() {
     const ext = getExtension(state.currentFilename);
     const isJson = ext === 'json';
     const isMd = ext === 'md';
+    const isCode = CODE_EXTENSIONS.has(ext);
 
     const ds = isJson ? detectDatasheetMode(document.getElementById('source-editor').value) : { isDatasheet: false };
     const jt = isJson ? detectJsonType(document.getElementById('source-editor').value) : { isObject: false, isArray: false };
@@ -418,6 +432,7 @@ function updateModeToolbar() {
     modeToolbar.innerHTML = `
         <button class="btn btn-sm${state.editorMode === 'source' ? ' active' : ''}" id="mode-source">Source</button>
         ${isMd ? `<button class="btn btn-sm${state.editorMode === 'wysiwyg' ? ' active' : ''}" id="mode-wysiwyg">Preview</button>` : ''}
+        ${(isCode || isJson) ? `<button class="btn btn-sm${state.editorMode === 'highlight' ? ' active' : ''}" id="mode-highlight">View</button>` : ''}
         ${(isJson && ds.isDatasheet) ? `<button class="btn btn-sm${state.editorMode === 'datasheet' ? ' active' : ''}" id="mode-datasheet">Datasheet</button>` : ''}
         ${(isJson && (jt.isObject || jt.isArray)) ? `<button class="btn btn-sm${state.editorMode === 'treeview' ? ' active' : ''}" id="mode-treeview">Tree</button>` : ''}
         <span id="filename-display" class="filename-display">${escapeHtml(state.currentFilename)}</span>
@@ -425,6 +440,7 @@ function updateModeToolbar() {
 
     document.getElementById('mode-source')?.addEventListener('click', () => switchToMode('source'));
     document.getElementById('mode-wysiwyg')?.addEventListener('click', () => switchToMode('wysiwyg'));
+    document.getElementById('mode-highlight')?.addEventListener('click', () => switchToMode('highlight'));
     document.getElementById('mode-datasheet')?.addEventListener('click', () => switchToMode('datasheet'));
     document.getElementById('mode-treeview')?.addEventListener('click', () => switchToMode('treeview'));
 }
@@ -715,6 +731,15 @@ function switchToMode(mode, content) {
             state.treeviewCollapsed = new Set();
             treeview.style.display = 'block';
             renderTreeView();
+            break;
+        }
+
+        case 'highlight': {
+            const lang = getExtension(state.currentFilename);
+            wysiwyg.style.display = 'block';
+            wysiwyg.className = 'code-highlight-view';
+            wysiwyg.contentEditable = 'false';
+            wysiwyg.innerHTML = `<pre class="code-highlight-pre"><code>${highlightCode(currentContent, lang)}</code></pre>`;
             break;
         }
     }

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -20,6 +20,10 @@ const CODE_EXTENSIONS = new Set([
     'toml', 'sql', 'graphql', 'proto', 'tf', 'hcl', 'conf', 'ini', 'cfg',
 ]);
 
+const IMAGE_EXTENSIONS = new Set([
+    'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico', 'bmp', 'avif',
+]);
+
 // =========================================================================
 // State
 // =========================================================================
@@ -30,7 +34,9 @@ const state = {
     currentFileHandle: null,
     currentFilename: '',
     isDirty: false,
-    editorMode: 'source', // 'source' | 'wysiwyg' | 'highlight' | 'datasheet' | 'treeview'
+    editorMode: 'source', // 'source' | 'wysiwyg' | 'highlight' | 'datasheet' | 'treeview' | 'image'
+    imageObjectUrl: null,
+    scrollPositions: {},
     // JSON view state
     datasheetData: null,
     datasheetSchema: null,
@@ -66,6 +72,10 @@ function isTextFile(filename) {
     const ext = getExtension(filename);
     const name = filename.toLowerCase();
     return TEXT_EXTENSIONS.has(ext) || name === 'dockerfile' || name === 'makefile' || name.startsWith('.');
+}
+
+function isImageFile(filename) {
+    return IMAGE_EXTENSIONS.has(getExtension(filename));
 }
 
 // =========================================================================
@@ -355,12 +365,27 @@ async function openFile(fileHandle, filename) {
         li.classList.toggle('active', li.querySelector('.name')?.textContent === filename);
     });
 
+    // Reset scroll positions for new file
+    state.scrollPositions = {};
+
     let content = '';
     if (isTextFile(filename)) {
         try {
             content = await readFile(fileHandle);
         } catch (err) {
             alert(`Failed to read file: ${err.message}`);
+            return;
+        }
+    } else if (isImageFile(filename)) {
+        if (state.imageObjectUrl) {
+            URL.revokeObjectURL(state.imageObjectUrl);
+            state.imageObjectUrl = null;
+        }
+        try {
+            const file = await fileHandle.getFile();
+            state.imageObjectUrl = URL.createObjectURL(file);
+        } catch (err) {
+            alert(`Failed to read image: ${err.message}`);
             return;
         }
     }
@@ -380,6 +405,12 @@ async function openFile(fileHandle, filename) {
 }
 
 function determineInitialMode(ext, content) {
+    // Image files
+    if (IMAGE_EXTENSIONS.has(ext)) {
+        state.editorMode = 'image';
+        return;
+    }
+
     // JSON: treeview if valid, else source
     if (ext === 'json') {
         const jt = detectJsonType(content);
@@ -420,6 +451,7 @@ function renderEditor(content, filename) {
 
 function updateModeToolbar() {
     const ext = getExtension(state.currentFilename);
+    const isImage = IMAGE_EXTENSIONS.has(ext);
     const isJson = ext === 'json';
     const isMd = ext === 'md';
 
@@ -427,6 +459,12 @@ function updateModeToolbar() {
     const hasTree = isJson && (jt.isObject || jt.isArray);
 
     const modeToolbar = document.getElementById('mode-toolbar');
+
+    if (isImage) {
+        modeToolbar.innerHTML = `<span id="filename-display" class="filename-display">${escapeHtml(state.currentFilename)}</span>`;
+        return;
+    }
+
     modeToolbar.innerHTML = `
         <button class="btn btn-sm${state.editorMode === 'source' ? ' active' : ''}" id="mode-source">Source</button>
         ${isMd ? `<button class="btn btn-sm${state.editorMode === 'wysiwyg' ? ' active' : ''}" id="mode-wysiwyg">Preview</button>` : ''}
@@ -716,7 +754,19 @@ function updateSourceHighlight() {
     }
 }
 
+function _scrollElForMode(mode) {
+    if (mode === 'source') return document.getElementById('source-editor');
+    if (mode === 'wysiwyg') return document.getElementById('wysiwyg');
+    if (mode === 'treeview') return document.getElementById('s3-treeview');
+    if (mode === 'image') return document.getElementById('image-viewer');
+    return null;
+}
+
 function switchToMode(mode, content) {
+    // Save scroll position of current panel before switching
+    const prevEl = _scrollElForMode(state.editorMode);
+    if (prevEl) state.scrollPositions[state.editorMode] = prevEl.scrollTop;
+
     state.editorMode = mode;
 
     const wrap = document.getElementById('source-editor-wrap');
@@ -724,12 +774,14 @@ function switchToMode(mode, content) {
     const wysiwyg = document.getElementById('wysiwyg');
     const datasheet = document.getElementById('s3-datasheet');
     const treeview = document.getElementById('s3-treeview');
+    const imageViewer = document.getElementById('image-viewer');
 
     // Hide all panels
     wrap.style.display = 'none';
     wysiwyg.style.display = 'none';
     datasheet.style.display = 'none';
     treeview.style.display = 'none';
+    imageViewer.style.display = 'none';
 
     const currentContent = content !== undefined ? content : textarea.value;
 
@@ -762,7 +814,18 @@ function switchToMode(mode, content) {
             break;
         }
 
+        case 'image':
+            imageViewer.style.display = 'flex';
+            imageViewer.innerHTML = state.imageObjectUrl
+                ? `<img src="${state.imageObjectUrl}" alt="${escapeHtml(state.currentFilename)}">`
+                : `<p style="color:var(--color-text-tertiary)">Failed to load image</p>`;
+            break;
+
     }
+
+    // Restore scroll position for this mode (0 = top if not previously saved)
+    const newEl = _scrollElForMode(mode);
+    if (newEl) newEl.scrollTop = state.scrollPositions[mode] || 0;
 
     // Update toolbar buttons
     document.querySelectorAll('#mode-toolbar .btn').forEach(btn => {

--- a/js/lib-markdown.js
+++ b/js/lib-markdown.js
@@ -138,8 +138,13 @@
             return protect(`<del data-md="${escapeHtml(match)}">${content}</del>`);
         });
 
-        // Restore protected spans
-        result = result.replace(/\uFFFE(\d+)\uFFFE/g, (_, i) => spans[parseInt(i, 10)]);
+        // Restore protected spans — loop until stable so nested protections
+        // (e.g. image inside a link) are fully resolved in multiple passes
+        let _prev;
+        do {
+            _prev = result;
+            result = result.replace(/\uFFFE(\d+)\uFFFE/g, (_, i) => spans[parseInt(i, 10)]);
+        } while (result !== _prev);
 
         return result;
     }


### PR DESCRIPTION
## Summary
- `white-space: pre` → `pre-wrap` on the textarea, highlight backdrop, and backdrop `<code>`
- `word-break: break-word` added to handle long unbroken strings
- Line numbers remain logical (count `\n` characters) — correct behavior

## Test plan
- [ ] Open a file with long lines — they wrap instead of creating a horizontal scrollbar
- [ ] Syntax highlighting backdrop stays in sync with textarea (no visual misalignment)
- [ ] Line numbers still count correctly (one number per newline, not per visual row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)