### PR TITLE
UI polish, treeview sidebar, and fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -177,9 +177,9 @@ header {
 
 .logo {
     font-family: var(--font-mono);
-    font-size: 1.08rem;
+    font-size: 1.35rem;
     font-weight: 900;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
     white-space: nowrap;
     margin-right: 0.5rem;
@@ -299,8 +299,10 @@ main {
     gap: 0.25rem;
     padding: 0.375rem 0.625rem;
     background: var(--color-bg-toolbar);
-    border-bottom: 1px solid var(--color-border-primary);
+    box-shadow: 0 1px 0 var(--color-border-primary), 0 2px 6px rgba(0,0,0,0.20);
     flex-shrink: 0;
+    position: relative;
+    z-index: 1;
 }
 
 #file-list {
@@ -311,50 +313,53 @@ main {
 }
 
 .file-entry {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.3rem 0.75rem;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    color: var(--color-text-secondary);
     position: relative;
     user-select: none;
-    border-radius: var(--panel-border-radius);
     margin: 0 0.25rem;
 }
 
-.file-entry:hover {
+.file-entry-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.3rem 0.75rem 0.3rem 0.5rem;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    border-radius: var(--panel-border-radius);
+}
+
+.file-entry-row:hover {
     background: var(--color-bg-tertiary);
     color: var(--color-text-primary);
 }
 
-.file-entry.active {
+.file-entry.active > .file-entry-row {
     background: var(--color-bg-tertiary);
     color: var(--color-text-primary);
     box-shadow: inset 2px 0 0 var(--color-text-primary);
 }
 
-.file-entry .icon {
+.file-entry-row .icon {
     flex-shrink: 0;
     display: flex;
     align-items: center;
     color: var(--color-text-tertiary);
 }
 
-.file-entry.active .icon,
-.file-entry:hover .icon {
+.file-entry.active > .file-entry-row .icon,
+.file-entry-row:hover .icon {
     color: var(--color-text-secondary);
 }
 
-.file-entry .name {
+.file-entry-row .name {
     flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.file-entry .delete-btn {
+.file-entry-row .delete-btn {
     display: none;
     background: none;
     border: none;
@@ -370,13 +375,47 @@ main {
     border-radius: var(--panel-border-radius);
 }
 
-.file-entry:hover .delete-btn {
+.file-entry-row:hover .delete-btn {
     display: flex;
 }
 
-.file-entry .delete-btn:hover {
+.file-entry-row .delete-btn:hover {
     color: var(--color-text-primary);
     background: var(--color-bg-tertiary);
+}
+
+/* Folder toggle chevron */
+.folder-toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-tertiary);
+    cursor: pointer;
+    transition: transform 0.12s ease;
+}
+
+.file-entry.expanded > .file-entry-row .folder-toggle {
+    transform: rotate(90deg);
+}
+
+/* Indented child list for expanded folders */
+.folder-children {
+    list-style: none;
+    padding: 0;
+    padding-left: 1.0rem;
+    margin: 0;
+}
+
+/* Spacer so file rows align with folder rows (no toggle) */
+.file-entry-row .toggle-spacer {
+    width: 1rem;
+    flex-shrink: 0;
 }
 
 .new-file-input-wrap {

--- a/css/style.css
+++ b/css/style.css
@@ -340,6 +340,15 @@ main {
     box-shadow: inset 2px 0 0 var(--color-text-primary);
 }
 
+.file-entry.disabled > .file-entry-row {
+    opacity: 0.38;
+    cursor: default;
+}
+.file-entry.disabled > .file-entry-row:hover {
+    background: none;
+    color: var(--color-text-secondary);
+}
+
 .file-entry-row .icon {
     flex-shrink: 0;
     display: flex;

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -218,55 +218,104 @@ async function renderSidebar() {
 
     list.innerHTML = '';
     for (const entry of entries) {
-        const li = renderFileEntry(entry);
+        const li = renderFileEntry(entry, state.currentDirHandle);
         list.appendChild(li);
     }
 }
 
-function renderFileEntry(entry) {
+const CHEVRON_SVG = `<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>`;
+const DELETE_SVG = `<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>`;
+
+function renderFileEntry(entry, parentHandle) {
     const li = document.createElement('li');
     li.className = 'file-entry';
-    if (entry.name === state.currentFilename && entry.kind === 'file') {
+    if (entry.kind === 'file' && entry.name === state.currentFilename) {
         li.classList.add('active');
     }
 
     const icon = getFileIconSvg(entry.name, entry.kind);
-    li.innerHTML = `
-        <span class="icon">${icon}</span>
-        <span class="name" title="${escapeHtml(entry.name)}">${escapeHtml(entry.name)}</span>
-        <button class="delete-btn" title="Delete ${escapeHtml(entry.name)}" aria-label="Delete ${escapeHtml(entry.name)}"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
-    `;
+    const deleteBtn = `<button class="delete-btn" title="Delete ${escapeHtml(entry.name)}" aria-label="Delete ${escapeHtml(entry.name)}">${DELETE_SVG}</button>`;
 
-    // Click handler
-    li.addEventListener('click', async (e) => {
-        if (e.target.classList.contains('delete-btn')) return;
-        if (entry.kind === 'directory') {
-            // Drill into folder
-            state.pathStack.push({ handle: entry.handle, name: entry.name });
-            state.currentDirHandle = entry.handle;
-            await renderSidebar();
-            renderBreadcrumb();
-        } else {
+    if (entry.kind === 'directory') {
+        li.innerHTML = `<div class="file-entry-row">
+            <button class="folder-toggle" aria-label="Toggle ${escapeHtml(entry.name)}">${CHEVRON_SVG}</button>
+            <span class="icon">${icon}</span>
+            <span class="name" title="${escapeHtml(entry.name)}">${escapeHtml(entry.name)}</span>
+            ${deleteBtn}
+        </div>`;
+
+        li.querySelector('.file-entry-row').addEventListener('click', async (e) => {
+            if (e.target.closest('.delete-btn')) return;
+            await toggleFolder(li, entry.handle);
+        });
+    } else {
+        li.innerHTML = `<div class="file-entry-row">
+            <span class="toggle-spacer"></span>
+            <span class="icon">${icon}</span>
+            <span class="name" title="${escapeHtml(entry.name)}">${escapeHtml(entry.name)}</span>
+            ${deleteBtn}
+        </div>`;
+
+        li.querySelector('.file-entry-row').addEventListener('click', async (e) => {
+            if (e.target.closest('.delete-btn')) return;
             await openFile(entry.handle, entry.name);
-        }
-    });
+        });
+    }
 
-    // Delete button
     li.querySelector('.delete-btn').addEventListener('click', async (e) => {
         e.stopPropagation();
         if (!confirm(`Delete "${entry.name}"?`)) return;
+        const dirHandle = parentHandle || state.currentDirHandle;
         try {
-            await deleteEntry(entry.name);
-            if (entry.name === state.currentFilename) {
+            await dirHandle.removeEntry(entry.name, { recursive: true });
+            if (entry.kind === 'file' && entry.name === state.currentFilename) {
                 clearEditor();
             }
-            await renderSidebar();
+            // Remove the entry from DOM directly if it's a nested entry
+            if (parentHandle) {
+                li.remove();
+            } else {
+                await renderSidebar();
+            }
         } catch (err) {
             alert(`Failed to delete: ${err.message}`);
         }
     });
 
     return li;
+}
+
+async function toggleFolder(li, handle) {
+    const isExpanded = li.classList.contains('expanded');
+    if (isExpanded) {
+        li.querySelector('.folder-children')?.remove();
+        li.classList.remove('expanded');
+        return;
+    }
+
+    li.classList.add('expanded');
+    let entries;
+    try {
+        entries = await listDirectory(handle);
+    } catch (err) {
+        li.classList.remove('expanded');
+        alert(`Failed to read folder: ${err.message}`);
+        return;
+    }
+
+    const childUl = document.createElement('ul');
+    childUl.className = 'folder-children';
+    if (!entries.length) {
+        const emptyLi = document.createElement('li');
+        emptyLi.style.cssText = 'color:var(--color-text-tertiary);padding:0.2rem 0.75rem;font-size:0.75rem;font-style:italic';
+        emptyLi.textContent = 'Empty folder';
+        childUl.appendChild(emptyLi);
+    } else {
+        for (const child of entries) {
+            childUl.appendChild(renderFileEntry(child, handle));
+        }
+    }
+    li.appendChild(childUl);
 }
 
 function getFileIconSvg(name, kind) {
@@ -369,14 +418,7 @@ async function openFile(fileHandle, filename) {
     state.scrollPositions = {};
 
     let content = '';
-    if (isTextFile(filename)) {
-        try {
-            content = await readFile(fileHandle);
-        } catch (err) {
-            alert(`Failed to read file: ${err.message}`);
-            return;
-        }
-    } else if (isImageFile(filename)) {
+    if (isImageFile(filename)) {
         if (state.imageObjectUrl) {
             URL.revokeObjectURL(state.imageObjectUrl);
             state.imageObjectUrl = null;
@@ -386,6 +428,13 @@ async function openFile(fileHandle, filename) {
             state.imageObjectUrl = URL.createObjectURL(file);
         } catch (err) {
             alert(`Failed to read image: ${err.message}`);
+            return;
+        }
+    } else {
+        try {
+            content = await readFile(fileHandle);
+        } catch (err) {
+            alert(`Failed to read file: ${err.message}`);
             return;
         }
     }

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -24,6 +24,27 @@ const IMAGE_EXTENSIONS = new Set([
     'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico', 'bmp', 'avif',
 ]);
 
+const BINARY_EXTENSIONS = new Set([
+    // Executables & compiled
+    'exe', 'dll', 'so', 'dylib', 'bin', 'out', 'class', 'pyc', 'pyo', 'pyd',
+    'o', 'a', 'lib', 'wasm', 'app',
+    // Archives
+    'zip', 'tar', 'gz', 'bz2', 'xz', '7z', 'rar', 'zst', 'lz4', 'lzma',
+    'pkg', 'deb', 'rpm', 'dmg', 'msi', 'apk', 'ipa',
+    // Documents (binary)
+    'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'odt', 'ods', 'odp',
+    // Fonts
+    'ttf', 'otf', 'woff', 'woff2', 'eot',
+    // Audio
+    'mp3', 'wav', 'flac', 'ogg', 'm4a', 'aac', 'opus', 'aiff',
+    // Video
+    'mp4', 'avi', 'mov', 'mkv', 'webm', 'm4v', 'wmv', 'flv',
+    // Database
+    'sqlite', 'sqlite3', 'db',
+]);
+
+const MAX_OPENABLE_SIZE = 10 * 1024 * 1024; // 10 MB
+
 // =========================================================================
 // State
 // =========================================================================
@@ -78,6 +99,20 @@ function isImageFile(filename) {
     return IMAGE_EXTENSIONS.has(getExtension(filename));
 }
 
+function isUnopenable(entry) {
+    if (entry.kind !== 'file') return false;
+    if (IMAGE_EXTENSIONS.has(getExtension(entry.name))) return false; // images are viewable
+    if (BINARY_EXTENSIONS.has(getExtension(entry.name))) return true;
+    if (entry.size != null && entry.size > MAX_OPENABLE_SIZE) return true;
+    return false;
+}
+
+function formatSize(bytes) {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 // =========================================================================
 // File System Helpers
 // =========================================================================
@@ -95,17 +130,25 @@ async function writeFile(fileHandle, content) {
 
 async function listDirectory(dirHandle) {
     const dirs = [];
-    const files = [];
+    const fileHandles = [];
     for await (const [name, handle] of dirHandle.entries()) {
         if (name.startsWith('.')) continue; // skip hidden
         if (handle.kind === 'directory') {
             dirs.push({ name, handle, kind: 'directory' });
         } else {
-            files.push({ name, handle, kind: 'file' });
+            fileHandles.push({ name, handle });
         }
     }
     dirs.sort((a, b) => a.name.localeCompare(b.name));
+
+    // Fetch file sizes in parallel to determine openability
+    const files = await Promise.all(fileHandles.map(async ({ name, handle }) => {
+        let size = 0;
+        try { size = (await handle.getFile()).size; } catch (_) {}
+        return { name, handle, kind: 'file', size };
+    }));
     files.sort((a, b) => a.name.localeCompare(b.name));
+
     return [...dirs, ...files];
 }
 
@@ -249,17 +292,29 @@ function renderFileEntry(entry, parentHandle) {
             await toggleFolder(li, entry.handle);
         });
     } else {
-        li.innerHTML = `<div class="file-entry-row">
+        const unopenable = isUnopenable(entry);
+        if (unopenable) li.classList.add('disabled');
+
+        const reason = BINARY_EXTENSIONS.has(getExtension(entry.name))
+            ? 'Binary file'
+            : `Large file (${formatSize(entry.size)})`;
+        const tooltip = unopenable
+            ? `${escapeHtml(entry.name)} — ${reason}`
+            : escapeHtml(entry.name);
+
+        li.innerHTML = `<div class="file-entry-row" title="${tooltip}">
             <span class="toggle-spacer"></span>
             <span class="icon">${icon}</span>
-            <span class="name" title="${escapeHtml(entry.name)}">${escapeHtml(entry.name)}</span>
+            <span class="name">${escapeHtml(entry.name)}</span>
             ${deleteBtn}
         </div>`;
 
-        li.querySelector('.file-entry-row').addEventListener('click', async (e) => {
-            if (e.target.closest('.delete-btn')) return;
-            await openFile(entry.handle, entry.name);
-        });
+        if (!unopenable) {
+            li.querySelector('.file-entry-row').addEventListener('click', async (e) => {
+                if (e.target.closest('.delete-btn')) return;
+                await openFile(entry.handle, entry.name);
+            });
+        }
     }
 
     li.querySelector('.delete-btn').addEventListener('click', async (e) => {

--- a/js/lib-markdown.js
+++ b/js/lib-markdown.js
@@ -95,7 +95,13 @@
         // Uses \uFFFE (Unicode non-character) as a sentinel that won't appear in markdown.
         const spans = [];
         function protect(html) {
-            spans.push(html);
+            // Escape any \uFFFE sentinels inside attribute values (="...") so
+            // the multi-pass unprotect loop cannot expand them into raw HTML
+            // inside attribute strings. \uFFFD is used as the safe substitute —
+            // it won't match the /\uFFFE(\d+)\uFFFE/ unprotect pattern.
+            const safe = html.replace(/="[^"]*\uFFFE[^"]*"/g, attr =>
+                attr.replace(/\uFFFE/g, '\uFFFD'));
+            spans.push(safe);
             return `\uFFFE${spans.length - 1}\uFFFE`;
         }
 


### PR DESCRIPTION
## Summary
- Sidebar folders are now collapsible in-place (chevron treeview) instead of navigate-into
- Files with unknown extensions now open as text (previously silently showed empty)
- Sidebar toolbar shadow now matches mode-toolbar for consistent elevation
- Logo: 25% larger (1.35rem), tighter letter-spacing (0.04em)
- Markdown link rendering fixes: nested protection marker multi-pass unprotect + attribute value escaping

## Test plan
- [ ] Open a folder; verify folders show a chevron toggle
- [ ] Expand/collapse a folder; verify children load and indent correctly
- [ ] Nested expand/collapse works
- [ ] Delete button on nested entries works
- [ ] Open a file with unknown extension (e.g. `.xyz`) — should open in source mode with content
- [ ] Sidebar toolbar and mode toolbar shadows look identical
- [ ] Logo is visibly larger and letters are tighter
- [ ] Markdown preview renders `**[link](url)**` and `[![badge](img)](url)` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)