### PR TITLE
Reset breadcrumb font size to normal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -238,7 +238,7 @@ html[data-theme="light"] .logo {
     align-items: center;
     gap: 0.25rem;
     overflow: hidden;
-    font-size: 1.4625rem;
+    font-size: inherit;
     color: var(--color-text-secondary);
     min-width: 0;
     padding: 0 0.5rem;


### PR DESCRIPTION
## Summary

- Reverts the 80% breadcrumb font size increase (`1.4625rem`) to `inherit`, matching the rest of the navbar.

## Test plan

- [ ] Verify breadcrumb text is the same size as other navbar text

🤖 Generated with [Claude Code](https://claude.com/claude-code)