### PR TITLE
README update and breadcrumb font fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# HotNote2
+# Hotnote
+
+[https://hotnote.io](https://hotnote.io)
+
+Minimalist online code editor with local filesystem access.
+
+We ❤️ lean software and dream of the days of MS Edit and Windows 3.11.
 
 A pure-JS, no-build notes app that runs directly in the browser. Uses the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) to read and write files on your local machine.
 

--- a/css/style.css
+++ b/css/style.css
@@ -238,7 +238,7 @@ html[data-theme="light"] .logo {
     align-items: center;
     gap: 0.25rem;
     overflow: hidden;
-    font-size: 1.4625rem;
+    font-size: inherit;
     color: var(--color-text-secondary);
     min-width: 0;
     padding: 0 0.5rem;


### PR DESCRIPTION
## Summary

- Rename README heading to `Hotnote`, add hotnote.io link and tagline
- Reset breadcrumb font size to `inherit` (reverts the 80% increase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)