### PR TITLE
Mobile UI improvements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1185,3 +1185,30 @@ main {
     background: var(--color-bg-tertiary);
     outline: 1px inset var(--color-border-primary);
 }
+
+/* =====================================================================
+   Mobile
+   ===================================================================== */
+@media (max-width: 720px) {
+    header {
+        padding: 0.5rem 0.4rem;
+        gap: 0.1rem;
+    }
+
+    .header-left,
+    .header-right {
+        gap: 0.1rem;
+    }
+
+    .logo {
+        display: none;
+    }
+
+    .autosave-toggle {
+        display: none;
+    }
+
+    #breadcrumb {
+        padding: 0 0.15rem;
+    }
+}

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -571,6 +571,11 @@ async function openFile(fileHandle, filename) {
         autosaveCheckbox.checked = state.autosaveEnabled;
     }
     if (autosaveToggleLabel) autosaveToggleLabel.style.opacity = '';
+
+    // On narrow viewports, collapse sidebar after picking a file
+    if (window.innerWidth <= 720) {
+        document.getElementById('sidebar')?.classList.add('collapsed');
+    }
 }
 
 function determineInitialMode(ext, content) {

--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -1636,12 +1636,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Check if File System Access API is available
     if (!window.showDirectoryPicker) {
-        const isMobile = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent);
         const warning = document.createElement('div');
         warning.style.cssText = 'position:fixed;bottom:1rem;right:1rem;left:1rem;background:#f85149;color:#fff;padding:.75rem 1rem;border-radius:6px;font-size:.875rem;z-index:9999;text-align:center;';
-        warning.textContent = isMobile
-            ? 'Local file access is not supported on mobile browsers. Open hotnote.io on a desktop Chrome or Edge browser.'
-            : 'File System Access API not supported. Use Chrome or Edge.';
+        warning.textContent = 'File System Access API not supported. Use Chrome or Edge.';
         document.body.appendChild(warning);
     }
 });


### PR DESCRIPTION
## Summary

- Hide logo and autosave toggle on narrow viewports (≤720px)
- Tighten header padding and gap so all buttons fit on mobile
- Auto-collapse sidebar after a file is opened on mobile
- Remove incorrect mobile-specific API warning (Chrome on Android supports `showDirectoryPicker`)

## Test plan

- [ ] Open on mobile Chrome — confirm logo is hidden and buttons fit
- [ ] Pick a file on mobile — confirm sidebar closes automatically
- [ ] Verify no warning banner appears on mobile Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)