### PR TITLE
Use preview.jpg for social media cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,16 +23,15 @@
     <meta property="og:url" content="https://hotnote.io/">
     <meta property="og:title" content="hotnote">
     <meta property="og:description" content="Minimalist online code editor with local filesystem access. No build step, no backend — runs entirely in the browser.">
-    <meta property="og:image" content="https://hotnote.io/icon-512.png">
-    <meta property="og:image:width" content="512">
-    <meta property="og:image:height" content="512">
+    <meta property="og:image" content="https://hotnote.io/preview.jpg">
+    <meta property="og:image:type" content="image/jpeg">
 
     <!-- Twitter / X Card -->
-    <meta name="twitter:card" content="summary">
+    <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://hotnote.io/">
     <meta name="twitter:title" content="hotnote">
     <meta name="twitter:description" content="Minimalist online code editor with local filesystem access. No build step, no backend — runs entirely in the browser.">
-    <meta name="twitter:image" content="https://hotnote.io/icon-512.png">
+    <meta name="twitter:image" content="https://hotnote.io/preview.jpg">
 
     <link rel="stylesheet" href="css/style.css">
     <script defer src="https://cloud.umami.is/script.js" data-website-id="bc47a3ae-96b5-4c31-9863-c6b27d72f0f4"></script>


### PR DESCRIPTION
## Summary

- Switch OG and Twitter card images from `icon-512.png` to `preview.jpg`
- Upgrade Twitter card type from `summary` to `summary_large_image` for a full-width preview

## Test plan

- [ ] Paste hotnote.io URL into a Twitter/X post preview — confirm large image appears
- [ ] Check Discord/Slack unfurl shows preview.jpg

🤖 Generated with [Claude Code](https://claude.com/claude-code)