### PR TITLE
Fix og:title length — add local-first description

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <!-- Open Graph (Facebook, LinkedIn, Discord, Slack, …) -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://hotnote.io/">
-    <meta property="og:title" content="hotnote">
+    <meta property="og:title" content="hotnote — local-first code editor in the browser">
     <meta property="og:description" content="Minimalist online code editor with local filesystem access. No build step, no backend — runs entirely in the browser.">
     <meta property="og:image" content="https://hotnote.io/preview.jpg">
     <meta property="og:image:type" content="image/jpeg">
@@ -29,7 +29,7 @@
     <!-- Twitter / X Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://hotnote.io/">
-    <meta name="twitter:title" content="hotnote">
+    <meta name="twitter:title" content="hotnote — local-first code editor in the browser">
     <meta name="twitter:description" content="Minimalist online code editor with local filesystem access. No build step, no backend — runs entirely in the browser.">
     <meta name="twitter:image" content="https://hotnote.io/preview.jpg">
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <!-- Open Graph (Facebook, LinkedIn, Discord, Slack, …) -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://hotnote.io/">
-    <meta property="og:title" content="hotnote — local-first code editor in the browser">
+    <meta property="og:title" content="hotnote — local-first code &amp; markdown editor">
     <meta property="og:description" content="Minimalist online code editor with local filesystem access. No build step, no backend — runs entirely in the browser.">
     <meta property="og:image" content="https://hotnote.io/preview.jpg">
     <meta property="og:image:type" content="image/jpeg">
@@ -29,7 +29,7 @@
     <!-- Twitter / X Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://hotnote.io/">
-    <meta name="twitter:title" content="hotnote — local-first code editor in the browser">
+    <meta name="twitter:title" content="hotnote — local-first code &amp; markdown editor">
     <meta name="twitter:description" content="Minimalist online code editor with local filesystem access. No build step, no backend — runs entirely in the browser.">
     <meta name="twitter:image" content="https://hotnote.io/preview.jpg">
 


### PR DESCRIPTION
## Summary
- `og:title` and `twitter:title` were just "hotnote" (7 chars), below the recommended 30-60 character range
- Updated to "hotnote — local-first code editor in the browser" (49 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)