### PR TITLE
Restore editor mode when navigating file history

### DIFF
--- a/js/hotnote.js
+++ b/js/hotnote.js
@@ -613,6 +613,7 @@ async function navigateHistory(delta) {
         const sourceEditor = document.getElementById('source-editor');
         const scrollEl = _scrollElForMode(state.editorMode);
         curEntry.pos = {
+            editorMode: state.editorMode,
             cursorStart: sourceEditor?.selectionStart ?? 0,
             cursorEnd: sourceEditor?.selectionEnd ?? 0,
             scrollPositions: {
@@ -626,12 +627,16 @@ async function navigateHistory(delta) {
     const { handle, name, pos } = state.fileHistory[target];
     await openFile(handle, name, false);
 
-    // Restore cursor + scroll for the target file
+    // Restore mode, cursor, and scroll for the target file
     if (pos) {
         if (pos.scrollPositions) {
             state.scrollPositions = { ...pos.scrollPositions };
+        }
+        if (pos.editorMode && pos.editorMode !== state.editorMode) {
+            switchToMode(pos.editorMode); // also restores scroll from state.scrollPositions
+        } else {
             const scrollEl = _scrollElForMode(state.editorMode);
-            if (scrollEl) scrollEl.scrollTop = pos.scrollPositions[state.editorMode] || 0;
+            if (scrollEl) scrollEl.scrollTop = (pos.scrollPositions?.[state.editorMode]) || 0;
         }
         const sourceEditor = document.getElementById('source-editor');
         if (sourceEditor && pos.cursorStart !== undefined) {


### PR DESCRIPTION
## Summary
- Saves the current editor mode (source/preview/treeview) to the history entry before navigating away
- On back/forward, switches to the saved mode if it differs from the file's default, then restores scroll position

## Test plan
- [ ] Open a markdown file, switch to Preview, open another file, click back — returns to Preview
- [ ] Open a JSON file, switch to Tree view, open another file, click back — returns to Tree view
- [ ] Open a file in Source, navigate away and back — stays in Source

🤖 Generated with [Claude Code](https://claude.com/claude-code)